### PR TITLE
Fix compiler errors (clang)

### DIFF
--- a/DirectXMesh/DirectXMeshAdjacency.cpp
+++ b/DirectXMesh/DirectXMeshAdjacency.cpp
@@ -287,7 +287,7 @@ namespace
                         {
                             XMVECTOR inner = XMLoadFloat3(&positions[curIndex]);
 
-                            XMVECTOR diff = XMVector3LengthSq(inner - outer);
+                            XMVECTOR diff = XMVector3LengthSq(XMVectorSubtract(inner, outer));
 
                             if (XMVector2Less(diff, vepsilon))
                             {
@@ -482,8 +482,8 @@ namespace
                             XMVECTOR pB2 = XMLoadFloat3(&positions[va]);
                             XMVECTOR pB3 = XMLoadFloat3(&positions[vOther]);
 
-                            XMVECTOR v12 = pB1 - pB2;
-                            XMVECTOR v13 = pB1 - pB3;
+                            XMVECTOR v12 = XMVectorSubtract(pB1, pB2);
+                            XMVECTOR v13 = XMVectorSubtract(pB1, pB3);
 
                             XMVECTOR bnormal = XMVector3Normalize(XMVector3Cross(v12, v13));
 
@@ -493,8 +493,8 @@ namespace
                                 XMVECTOR pA2 = XMLoadFloat3(&positions[found->v2]);
                                 XMVECTOR pA3 = XMLoadFloat3(&positions[found->vOther]);
 
-                                v12 = pA1 - pA2;
-                                v13 = pA1 - pA3;
+                                v12 = XMVectorSubtract(pA1, pA2);
+                                v13 = XMVectorSubtract(pA1, pA3);
 
                                 XMVECTOR anormal = XMVector3Normalize(XMVector3Cross(v12, v13));
 
@@ -505,8 +505,8 @@ namespace
                             XMVECTOR pA2 = XMLoadFloat3(&positions[current->v2]);
                             XMVECTOR pA3 = XMLoadFloat3(&positions[current->vOther]);
 
-                            v12 = pA1 - pA2;
-                            v13 = pA1 - pA3;
+                            v12 = XMVectorSubtract(pA1, pA2);
+                            v13 = XMVectorSubtract(pA1, pA3);
 
                             XMVECTOR anormal = XMVector3Normalize(XMVector3Cross(v12, v13));
 

--- a/DirectXMesh/DirectXMeshNormals.cpp
+++ b/DirectXMesh/DirectXMeshNormals.cpp
@@ -55,8 +55,8 @@ namespace
             XMVECTOR p2 = XMLoadFloat3(&positions[i1]);
             XMVECTOR p3 = XMLoadFloat3(&positions[i2]);
 
-            XMVECTOR u = p2 - p1;
-            XMVECTOR v = p3 - p1;
+            XMVECTOR u = XMVectorSubtract(p2, p1);
+            XMVECTOR v = XMVectorSubtract(p3, p1);
 
             XMVECTOR faceNormal = XMVector3Normalize(XMVector3Cross(u, v));
 
@@ -124,8 +124,8 @@ namespace
             XMVECTOR p1 = XMLoadFloat3(&positions[i1]);
             XMVECTOR p2 = XMLoadFloat3(&positions[i2]);
 
-            XMVECTOR u = p1 - p0;
-            XMVECTOR v = p2 - p0;
+            XMVECTOR u = XMVectorSubtract(p1, p0);
+            XMVECTOR v = XMVectorSubtract(p2, p0);
 
             XMVECTOR faceNormal = XMVector3Normalize(XMVector3Cross(u, v));
 
@@ -137,15 +137,15 @@ namespace
             w0 = XMVectorACos(w0);
 
             // Corner 1 -> 2 - 1, 0 - 1
-            XMVECTOR c = XMVector3Normalize(p2 - p1);
-            XMVECTOR d = XMVector3Normalize(p0 - p1);
+            XMVECTOR c = XMVector3Normalize(XMVectorSubtract(p2, p1));
+            XMVECTOR d = XMVector3Normalize(XMVectorSubtract(p0, p1));
             XMVECTOR w1 = XMVector3Dot(c, d);
             w1 = XMVectorClamp(w1, g_XMNegativeOne, g_XMOne);
             w1 = XMVectorACos(w1);
 
             // Corner 2 -> 0 - 2, 1 - 2
-            XMVECTOR e = XMVector3Normalize(p0 - p2);
-            XMVECTOR f = XMVector3Normalize(p1 - p2);
+            XMVECTOR e = XMVector3Normalize(XMVectorSubtract(p0, p2));
+            XMVECTOR f = XMVector3Normalize(XMVectorSubtract(p1, p2));
             XMVECTOR w2 = XMVector3Dot(e, f);
             w2 = XMVectorClamp(w2, g_XMNegativeOne, g_XMOne);
             w2 = XMVectorACos(w2);
@@ -214,8 +214,8 @@ namespace
             XMVECTOR p1 = XMLoadFloat3(&positions[i1]);
             XMVECTOR p2 = XMLoadFloat3(&positions[i2]);
 
-            XMVECTOR u = p1 - p0;
-            XMVECTOR v = p2 - p0;
+            XMVECTOR u = XMVectorSubtract(p1, p0);
+            XMVECTOR v = XMVectorSubtract(p2, p0);
 
             XMVECTOR faceNormal = XMVector3Normalize(XMVector3Cross(u, v));
 
@@ -224,14 +224,14 @@ namespace
             w0 = XMVector3Length(w0);
 
             // Corner 1 -> 2 - 1, 0 - 1
-            XMVECTOR c = p2 - p1;
-            XMVECTOR d = p0 - p1;
+            XMVECTOR c = XMVectorSubtract(p2, p1);
+            XMVECTOR d = XMVectorSubtract(p0, p1);
             XMVECTOR w1 = XMVector3Cross(c, d);
             w1 = XMVector3Length(w1);
 
             // Corner 2 -> 0 - 2, 1 - 2
-            XMVECTOR e = p0 - p2;
-            XMVECTOR f = p1 - p2;
+            XMVECTOR e = XMVectorSubtract(p0, p2);
+            XMVECTOR f = XMVectorSubtract(p1, p2);
             XMVECTOR w2 = XMVector3Cross(e, f);
             w2 = XMVector3Length(w2);
 

--- a/DirectXMesh/DirectXMeshTangentFrame.cpp
+++ b/DirectXMesh/DirectXMeshTangentFrame.cpp
@@ -74,14 +74,14 @@ namespace
             XMVECTOR t1 = XMLoadFloat2(&texcoords[i1]);
             XMVECTOR t2 = XMLoadFloat2(&texcoords[i2]);
 
-            XMVECTOR s = XMVectorMergeXY(t1 - t0, t2 - t0);
+            XMVECTOR s = XMVectorMergeXY(XMVectorSubtract(t1, t0), XMVectorSubtract(t2, t0));
 
             XMFLOAT4A tmp;
             XMStoreFloat4A(&tmp, s);
 
             float d = tmp.x * tmp.w - tmp.z * tmp.y;
             d = (fabsf(d) <= EPSILON) ? 1.f : (1.f / d);
-            s *= d;
+            s = XMVectorScale(s, d);
             s = XMVectorMultiply(s, s_flips);
 
             XMMATRIX m0;
@@ -94,8 +94,8 @@ namespace
             XMVECTOR p2 = XMLoadFloat3(&positions[i2]);
 
             XMMATRIX m1;
-            m1.r[0] = p1 - p0;
-            m1.r[1] = p2 - p0;
+            m1.r[0] = XMVectorSubtract(p1, p0);
+            m1.r[1] = XMVectorSubtract(p2, p0);
             m1.r[2] = m1.r[3] = g_XMZero;
 
             XMMATRIX uv = XMMatrixMultiply(m0, m1);
@@ -116,11 +116,11 @@ namespace
             b0 = XMVector3Normalize(b0);
 
             XMVECTOR tan1 = tangent1[j];
-            XMVECTOR b1 = tan1 - XMVector3Dot(b0, tan1) * b0;
+            XMVECTOR b1 = XMVectorSubtract(tan1, XMVectorMultiply(XMVector3Dot(b0, tan1), b0));
             b1 = XMVector3Normalize(b1);
 
             XMVECTOR tan2 = tangent2[j];
-            XMVECTOR b2 = tan2 - XMVector3Dot(b0, tan2) * b0 - XMVector3Dot(b1, tan2) * b1;
+            XMVECTOR b2 = XMVectorSubtract(XMVectorSubtract(tan2, XMVectorMultiply(XMVector3Dot(b0, tan2), b0)), XMVectorMultiply(XMVector3Dot(b1, tan2), b1));
             b2 = XMVector3Normalize(b2);
 
             // handle degenerate vectors


### PR DESCRIPTION
The latest DirectXMath use a new ``_XM_NO_XMVECTOR_OVERLOADS_`` option in order to support building with clang--for details see [this blog post](https://blogs.msdn.microsoft.com/chuckw/2017/06/28/directxmath-3-11/). This means all client code that wants to build with clang also needs to avoid using DirectXMath XMVECTOR overloads.

This updates DirectXMesh's use of DirectXMath to build without the overloads.

