### PR TITLE
Ability to define RMA texture in OBJ's MTL.

### DIFF
--- a/Meshconvert/Mesh.cpp
+++ b/Meshconvert/Mesh.cpp
@@ -2017,6 +2017,18 @@ HRESULT Mesh::ExportToSDKMESH(const wchar_t* szFileName, size_t nMaterials, cons
                         *m2->EmissiveTexture = 0;
                     }
                 }
+
+                // Allow RMA texture material property to override drived name
+                if (!m0->rmaTexture.empty())
+                {
+                    int result = WideCharToMultiByte(CP_UTF8, WC_NO_BEST_FIT_CHARS,
+                        m0->rmaTexture.c_str(), -1,
+                        m2->RMATexture, MAX_TEXTURE_NAME, nullptr, FALSE);
+                    if (!result)
+                    {
+                        *m2->RMATexture = 0;
+                    }
+                }
             }
         }
     }

--- a/Meshconvert/Mesh.h
+++ b/Meshconvert/Mesh.h
@@ -98,6 +98,7 @@ public:
         std::wstring        normalTexture;
         std::wstring        specularTexture;
         std::wstring        emissiveTexture;
+        std::wstring        rmaTexture;
 
         Material() noexcept :
             perVertexColor(false),

--- a/Meshconvert/MeshOBJ.cpp
+++ b/Meshconvert/MeshOBJ.cpp
@@ -139,6 +139,7 @@ HRESULT LoadFromOBJ(
             {
                 mtl.emissiveTexture = ProcessTextureFileName(it->strEmissiveTexture, dds);
             }
+            mtl.rmaTexture = ProcessTextureFileName(it->strRMATexture, dds);
 
             inMaterial.push_back(mtl);
         }

--- a/Utilities/WaveFrontReader.h
+++ b/Utilities/WaveFrontReader.h
@@ -509,6 +509,12 @@ public:
                 LoadTexturePath(InFile, curMaterial->strEmissiveTexture, MAX_PATH);
                 curMaterial->bEmissive = true;
             }
+            else if (0 == wcscmp(strCommand.c_str(), L"map_RMA")
+                || 0 == wcscmp(strCommand.c_str(), L"map_occlusionRoughnessMetallic"))
+            {
+                // RMA texture
+                LoadTexturePath(InFile, curMaterial->strRMATexture, MAX_PATH);
+            }
             else
             {
                 // Unimplemented or unrecognized command
@@ -614,6 +620,7 @@ public:
         wchar_t strNormalTexture[MAX_PATH];
         wchar_t strSpecularTexture[MAX_PATH];
         wchar_t strEmissiveTexture[MAX_PATH];
+        wchar_t strRMATexture[MAX_PATH];
 
         Material() noexcept :
         vAmbient(0.2f, 0.2f, 0.2f),
@@ -628,7 +635,8 @@ public:
             strTexture{},
             strNormalTexture{},
             strSpecularTexture{},
-            strEmissiveTexture{}
+            strEmissiveTexture{},
+            strRMATexture{}
         {
         }
     };

--- a/Utilities/WaveFrontReader.h
+++ b/Utilities/WaveFrontReader.h
@@ -510,7 +510,7 @@ public:
                 curMaterial->bEmissive = true;
             }
             else if (0 == wcscmp(strCommand.c_str(), L"map_RMA")
-                || 0 == wcscmp(strCommand.c_str(), L"map_occlusionRoughnessMetallic"))
+                || 0 == wcscmp(strCommand.c_str(), L"map_ORM"))
             {
                 // RMA texture
                 LoadTexturePath(InFile, curMaterial->strRMATexture, MAX_PATH);


### PR DESCRIPTION
This adds the ability to define an RMA material within the OBJ's MTL via the command `map_RMA` or `map_occlusionRoughnessMetallic`.

This replaces the current implementation of using a presumed filename from the albeto name, often causing errors when using the PBREffectFactory.