### PR TITLE
Add CMake project and fix clang warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ Release
 x64
 /Tests
 /wiki
+/DirectXMesh/out

--- a/DirectXMesh/CMakeLists.txt
+++ b/DirectXMesh/CMakeLists.txt
@@ -36,11 +36,16 @@ add_library (directxmesh STATIC
     DirectXMeshWeldVertices.cpp
 )
 
+target_compile_options( directxmesh PRIVATE /fp:fast )
+
 if ( CMAKE_CXX_COMPILER_ID MATCHES "Clang" )
     target_compile_options( directxmesh PRIVATE -Wall -Wpedantic -Wextra )
+    if (${CMAKE_SIZEOF_VOID_P} EQUAL "4")
+        target_compile_options( directxmesh PRIVATE /arch:SSE2 )
+    endif()
 endif()
 if ( CMAKE_CXX_COMPILER_ID MATCHES "MSVC" )
-    target_compile_options( directxmesh PRIVATE /Wall /fp:fast /permissive- /Zc:__cplusplus )
+    target_compile_options( directxmesh PRIVATE /Wall /permissive- /Zc:__cplusplus )
 endif()
 
 # Windows 10 is used here to build the DirectX 12 code paths as well as 11

--- a/DirectXMesh/CMakeLists.txt
+++ b/DirectXMesh/CMakeLists.txt
@@ -1,0 +1,47 @@
+﻿# DirectXMesh geometry Library
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+#
+# http://go.microsoft.com/fwlink/?LinkID=324981
+
+cmake_minimum_required (VERSION 3.8)
+project (DirectXMesh_CMake LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/CMake")
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/CMake")
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/CMake")
+
+# Add source to this project's executable.
+add_library (directxmesh STATIC
+    DirectXMesh.h
+    DirectXMeshP.h
+    scoped.h
+    DirectXMeshAdjacency.cpp
+    DirectXMeshClean.cpp
+    DirectXMeshGSAdjacency.cpp
+    DirectXMeshNormals.cpp
+    DirectXMeshOptimize.cpp
+    DirectXMeshOptimizeLRU.cpp
+    DirectXMeshOptimizeTVC.cpp
+    DirectXMeshRemap.cpp
+    DirectXMeshTangentFrame.cpp
+    DirectXMeshUtil.cpp
+    DirectXMeshValidate.cpp
+    DirectXMeshVBReader.cpp
+    DirectXMeshVBWriter.cpp
+    DirectXMeshWeldVertices.cpp
+)
+
+if ( CMAKE_CXX_COMPILER_ID MATCHES "Clang" )
+    target_compile_options( directxmesh PRIVATE -Wall -Wpedantic -Wextra )
+endif()
+if ( CMAKE_CXX_COMPILER_ID MATCHES "MSVC" )
+    target_compile_options( directxmesh PRIVATE /Wall /fp:fast /permissive- /Zc:__cplusplus )
+endif()
+
+add_compile_definitions(_UNICODE UNICODE _WIN32_WINNT=0x0A00)

--- a/DirectXMesh/CMakeLists.txt
+++ b/DirectXMesh/CMakeLists.txt
@@ -16,7 +16,6 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/CMake")
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/CMake")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/CMake")
 
-# Add source to this project's executable.
 add_library (directxmesh STATIC
     DirectXMesh.h
     DirectXMeshP.h
@@ -44,4 +43,5 @@ if ( CMAKE_CXX_COMPILER_ID MATCHES "MSVC" )
     target_compile_options( directxmesh PRIVATE /Wall /fp:fast /permissive- /Zc:__cplusplus )
 endif()
 
+# Windows 10 is used here to build the DirectX 12 code paths as well as 11
 add_compile_definitions(_UNICODE UNICODE _WIN32_WINNT=0x0A00)

--- a/DirectXMesh/CMakeSettings.json
+++ b/DirectXMesh/CMakeSettings.json
@@ -1,0 +1,52 @@
+﻿{
+  "configurations": [
+    {
+      "name": "x86-Clang-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "-v",
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "clang_cl_x86" ],
+      "variables": []
+    },
+    {
+      "name": "x86-Clang-Release",
+      "generator": "Ninja",
+      "configurationType": "RelWithDebInfo",
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "-v",
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "clang_cl_x86" ],
+      "variables": []
+    },
+    {
+      "name": "x64-Clang-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "-v",
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "clang_cl_x64" ],
+      "variables": []
+    },
+    {
+      "name": "x64-Clang-Release",
+      "generator": "Ninja",
+      "configurationType": "RelWithDebInfo",
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "-v",
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "clang_cl_x64" ],
+      "variables": []
+    }
+  ]
+}

--- a/DirectXMesh/DirectXMesh.h
+++ b/DirectXMesh/DirectXMesh.h
@@ -232,7 +232,7 @@ namespace DirectX
     //---------------------------------------------------------------------------------
     // Normals, Tangents, and Bi-Tangents Computation
 
-    enum CNORM_FLAGS
+    enum CNORM_FLAGS : uint32_t
     {
         CNORM_DEFAULT                   = 0x0,
             // Default is to compute normals using weight-by-angle
@@ -304,7 +304,7 @@ namespace DirectX
     //---------------------------------------------------------------------------------
     // Mesh clean-up and validation
 
-    enum VALIDATE_FLAGS
+    enum VALIDATE_FLAGS : uint32_t
     {
         VALIDATE_DEFAULT                = 0x0,
 
@@ -369,7 +369,7 @@ namespace DirectX
         _Out_writes_(nFaces) uint32_t* faceRemap);
         // Reorders faces by attribute id
 
-    enum OPTFACES
+    enum OPTFACES : uint32_t
     {
         OPTFACES_V_DEFAULT      = 12,
         OPTFACES_R_DEFAULT      = 7,

--- a/DirectXMesh/DirectXMesh.h
+++ b/DirectXMesh/DirectXMesh.h
@@ -26,7 +26,7 @@
 #endif
 #endif
 
-#include <directxmath.h>
+#include <DirectXMath.h>
 
 #define DIRECTX_MESH_VERSION 130
 

--- a/DirectXMesh/DirectXMeshAdjacency.cpp
+++ b/DirectXMesh/DirectXMeshAdjacency.cpp
@@ -173,9 +173,10 @@ namespace
 
             for (size_t vert = 0; vert < nVerts; ++vert)
             {
-                uint32_t hashKey = (*reinterpret_cast<const uint32_t*>(&positions[vert].x)
-                    + *reinterpret_cast<const uint32_t*>(&positions[vert].y)
-                    + *reinterpret_cast<const uint32_t*>(&positions[vert].z)) % uint32_t(hashSize);
+                auto px = reinterpret_cast<const uint32_t*>(&positions[vert].x);
+                auto py = reinterpret_cast<const uint32_t*>(&positions[vert].y);
+                auto pz = reinterpret_cast<const uint32_t*>(&positions[vert].z);
+                uint32_t hashKey = (*px + *py + *pz) % uint32_t(hashSize);
 
                 uint32_t found = UNUSED32;
 

--- a/DirectXMesh/DirectXMeshOptimizeLRU.cpp
+++ b/DirectXMesh/DirectXMeshOptimizeLRU.cpp
@@ -22,13 +22,13 @@ namespace
 
     // code for computing vertex score was taken, as much as possible
     // directly from the original publication.
-    float ComputeVertexCacheScore(int cachePosition, uint32_t vertexCacheSize)
+    float ComputeVertexCacheScore(uint32_t cachePosition, uint32_t vertexCacheSize)
     {
         const float FindVertexScore_CacheDecayPower = 1.5f;
         const float FindVertexScore_LastTriScore = 0.75f;
 
         float score = 0.0f;
-        if (cachePosition < 0)
+        if (cachePosition >= vertexCacheSize)
         {
             // Vertex is not in FIFO cache - no score.
         }
@@ -46,8 +46,6 @@ namespace
             }
             else
             {
-                assert(cachePosition < int(vertexCacheSize));
-
                 // Points for being high in the cache.
                 const float scaler = 1.0f / (vertexCacheSize - 3);
                 score = 1.0f - (cachePosition - 3) * scaler;
@@ -172,8 +170,8 @@ namespace
             const OptimizeVertexData<IndexType> *vA = _vertexData + size_t(a) * 3;
             const OptimizeVertexData<IndexType> *vB = _vertexData + size_t(b) * 3;
 
-            int aValence = vA[0].activeFaceListSize + vA[1].activeFaceListSize + vA[2].activeFaceListSize;
-            int bValence = vB[0].activeFaceListSize + vB[1].activeFaceListSize + vB[2].activeFaceListSize;
+            uint32_t aValence = vA[0].activeFaceListSize + vA[1].activeFaceListSize + vA[2].activeFaceListSize;
+            uint32_t bValence = vB[0].activeFaceListSize + vB[1].activeFaceListSize + vB[2].activeFaceListSize;
 
             // higher scoring faces are those with lower valence totals
 

--- a/DirectXMesh/DirectXMeshP.h
+++ b/DirectXMesh/DirectXMeshP.h
@@ -46,6 +46,15 @@
 #pragma warning(disable : 4643)
 // C4643 Forward declaring in namespace std is not permitted by the C++ Standard
 
+#ifdef __clang__
+#pragma clang diagnostic ignored "-Wc++98-compat"
+#pragma clang diagnostic ignored "-Wc++98-compat-pedantic"
+#pragma clang diagnostic ignored "-Wc++98-compat-local-type-template-args"
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+#pragma clang diagnostic ignored "-Wfloat-equal"
+#pragma clang diagnostic ignored "-Wreserved-id-macro"
+#endif
+
 #pragma warning(push)
 #pragma warning(disable : 4005)
 #define WIN32_LEAN_AND_MEAN
@@ -62,7 +71,7 @@
 #define _WIN32_WINNT_WIN10 0x0A00
 #endif
 
-#include <windows.h>
+#include <Windows.h>
 
 #if defined(_XBOX_ONE) && defined(_TITLE)
 #include <d3d12_x.h>
@@ -76,8 +85,8 @@
 
 #define _XM_NO_XMVECTOR_OVERLOADS_
 
-#include <directxmath.h>
-#include <directxpackedvector.h>
+#include <DirectXMath.h>
+#include <DirectXPackedVector.h>
 
 #include <assert.h>
 #include <malloc.h>

--- a/DirectXMesh/DirectXMeshUtil.cpp
+++ b/DirectXMesh/DirectXMeshUtil.cpp
@@ -403,7 +403,7 @@ std::vector<std::pair<size_t, size_t>> DirectX::ComputeSubsets(const uint32_t* a
 
     if (!attributes)
     {
-        subsets.emplace_back(std::pair<size_t, size_t>(0, nFaces));
+        subsets.emplace_back(std::pair<size_t, size_t>(0u, nFaces));
         return subsets;
     }
 

--- a/DirectXMesh/DirectXMeshVBWriter.cpp
+++ b/DirectXMesh/DirectXMeshVBWriter.cpp
@@ -565,7 +565,7 @@ HRESULT VBWriter::Impl::Write(const XMVECTOR* buffer, const char* semanticName, 
             }
             v = XMVectorMultiply(v, s_Scale);
             XMStoreU555(reinterpret_cast<XMU555*>(ptr), v);
-            reinterpret_cast<XMU555*>(ptr)->w = (XMVectorGetW(v) > 0.5f) ? 1 : 0;
+            reinterpret_cast<XMU555*>(ptr)->w = (XMVectorGetW(v) > 0.5f) ? 1u : 0u;
             ptr += stride;
         }
     }


### PR DESCRIPTION
With VS 2019 Update 1 supporting the clang/LLVM toolset, I've formally added CMake files as well as addressed a number of clang warnings.