### PR TITLE
CMake package support

### DIFF
--- a/.nuget/directxmesh-config.cmake.in
+++ b/.nuget/directxmesh-config.cmake.in
@@ -1,5 +1,11 @@
 @PACKAGE_INIT@
 
-include(${CMAKE_CURRENT_LIST_DIR}/directxmesh-targets.cmake)
+if ((NOT directxmesh_FIND_COMPONENTS) OR ("library" IN_LIST directxmesh_FIND_COMPONENTS))
+  include(${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake)
+endif()
+
+if ("utils" IN_LIST directxmesh_FIND_COMPONENTS)
+  include(${CMAKE_CURRENT_LIST_DIR}/Utilities-targets.cmake)
+endif()
 
 check_required_components("@PROJECT_NAME@")

--- a/.nuget/directxmesh-config.cmake.in
+++ b/.nuget/directxmesh-config.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include(${CMAKE_CURRENT_LIST_DIR}/directxmesh-targets.cmake)
+
+check_required_components("@PROJECT_NAME@")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,15 @@
-﻿# DirectXMesh geometry Library
-#
-# Copyright (c) Microsoft Corporation. All rights reserved.
+﻿# Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-#
-# http://go.microsoft.com/fwlink/?LinkID=324981
 
 cmake_minimum_required (VERSION 3.11)
 
-project (DirectXMesh LANGUAGES CXX)
+set(DIRECTXMESH_VERSION 1.6.0)
+
+project(DirectXMesh
+  VERSION ${DIRECTXMESH_VERSION}
+  DESCRIPTION "DirectXMesh geometry Library"
+  HOMEPAGE_URL "https://go.microsoft.com/fwlink/?LinkID=324981"
+  LANGUAGES CXX)
 
 # Includes the support for DX 12 input layouts
 option(BUILD_DX12 "Build with DirectX12 Runtime support" ON)
@@ -22,8 +24,12 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/CMake")
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/CMake")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/CMake")
 
-set(LIBRARY_SOURCES
+#--- Library
+set(LIBRARY_HEADERS
     DirectXMesh/DirectXMesh.h
+    DirectXMesh/DirectXMesh.inl)
+
+set(LIBRARY_SOURCES
     DirectXMesh/DirectXMeshP.h
     DirectXMesh/scoped.h
     DirectXMesh/DirectXMeshAdjacency.cpp
@@ -42,11 +48,13 @@ set(LIBRARY_SOURCES
     DirectXMesh/DirectXMeshVBWriter.cpp
     DirectXMesh/DirectXMeshWeldVertices.cpp)
 
-add_library(${PROJECT_NAME} STATIC ${LIBRARY_SOURCES})
+add_library(${PROJECT_NAME} STATIC ${LIBRARY_SOURCES} ${LIBRARY_HEADERS})
 
 source_group(${PROJECT_NAME} REGULAR_EXPRESSION DirectXMesh/*.*)
 
-target_include_directories(${PROJECT_NAME} PUBLIC DirectXMesh)
+target_include_directories(${PROJECT_NAME} PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/DirectXMesh>
+  $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
 
 if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.16")
     target_precompile_headers(${PROJECT_NAME} PRIVATE DirectXMesh/DirectXMeshP.h)
@@ -64,6 +72,38 @@ if(MSVC)
     string(REPLACE "/GR " "/GR- " CMAKE_CXX_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE})
 endif()
 
+#--- Package
+include(CMakePackageConfigHelpers)
+
+write_basic_package_version_file(
+  ${PROJECT_BINARY_DIR}/cmake/${PROJECT_NAME}-config-version.cmake
+  VERSION ${DIRECTXMESH_VERSION}
+  COMPATIBILITY AnyNewerVersion)
+
+install(TARGETS ${PROJECT_NAME}
+  EXPORT ${PROJECT_NAME}-targets
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)
+
+configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/.nuget/${PROJECT_NAME}-config.cmake.in
+  ${PROJECT_BINARY_DIR}/cmake/${PROJECT_NAME}-config.cmake
+  INSTALL_DESTINATION cmake/})
+
+install(EXPORT ${PROJECT_NAME}-targets
+  FILE ${PROJECT_NAME}-targets.cmake
+  DESTINATION cmake/)
+
+install(FILES ${LIBRARY_HEADERS}
+  DESTINATION include/${PROJECT_NAME})
+
+install(
+  FILES
+    ${PROJECT_BINARY_DIR}/cmake/${PROJECT_NAME}-config.cmake
+    ${PROJECT_BINARY_DIR}/cmake/${PROJECT_NAME}-config-version.cmake
+  DESTINATION cmake/)
+
+#--- Command-line tool
 add_executable(meshconvert
     Meshconvert/Meshconvert.cpp
     Meshconvert/MeshOBJ.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,7 @@ configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/.nuget/${PROJECT_NAME}
 
 install(EXPORT ${PROJECT_NAME}-targets
   FILE ${PROJECT_NAME}-targets.cmake
+  NAMESPACE Microsoft::
   DESTINATION cmake/)
 
 install(FILES ${LIBRARY_HEADERS}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-﻿# Copyright (c) Microsoft Corporation. All rights reserved.
+# Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
 cmake_minimum_required (VERSION 3.11)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,18 @@ if(MSVC)
     string(REPLACE "/GR " "/GR- " CMAKE_CXX_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE})
 endif()
 
+#--- Utilities
+set(UTILS_HEADERS
+    Utilities/WaveFrontReader.h)
+
+add_library(Utilities INTERFACE)
+
+source_group(Utilities REGULAR_EXPRESSION Utilities/*.*)
+
+target_include_directories(Utilities INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Utilities>
+  $<INSTALL_INTERFACE:utils>)
+
 #--- Package
 include(CMakePackageConfigHelpers)
 
@@ -84,7 +96,15 @@ install(TARGETS ${PROJECT_NAME}
   EXPORT ${PROJECT_NAME}-targets
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin)
+  RUNTIME DESTINATION bin
+  COMPONENT library)
+
+install(TARGETS Utilities
+  EXPORT Utilities-targets
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+  COMPONENT utils)
 
 configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/.nuget/${PROJECT_NAME}-config.cmake.in
   ${PROJECT_BINARY_DIR}/cmake/${PROJECT_NAME}-config.cmake
@@ -95,8 +115,16 @@ install(EXPORT ${PROJECT_NAME}-targets
   NAMESPACE Microsoft::
   DESTINATION cmake/)
 
+install(EXPORT Utilities-targets
+  FILE Utilities-targets.cmake
+  NAMESPACE Microsoft::DirectXMesh::
+  DESTINATION cmake/)
+
 install(FILES ${LIBRARY_HEADERS}
   DESTINATION include)
+
+install(FILES ${UTILS_HEADERS}
+  DESTINATION utils)
 
 install(
   FILES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ source_group(${PROJECT_NAME} REGULAR_EXPRESSION DirectXMesh/*.*)
 
 target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/DirectXMesh>
-  $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
+  $<INSTALL_INTERFACE:include>)
 
 if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.16")
     target_precompile_headers(${PROJECT_NAME} PRIVATE DirectXMesh/DirectXMeshP.h)
@@ -95,7 +95,7 @@ install(EXPORT ${PROJECT_NAME}-targets
   DESTINATION cmake/)
 
 install(FILES ${LIBRARY_HEADERS}
-  DESTINATION include/${PROJECT_NAME})
+  DESTINATION include)
 
 install(
   FILES


### PR DESCRIPTION
This PR updates the CMake support in DirectXMesh to support ``find_package(directxmesh CONFIG)``:

```
find_package(directxmesh CONFIG REQUIRED)

target_link_libraries(foo Microsoft::DirectXMesh)
```

The package supports two components. By default, you get the DirectXMesh.lib component which is "library":

```
find_package(directxmesh CONFIG REQUIRED COMPONENTS library)
```

You can opt-in to getting the ``WaveFrontReader.h`` as a component named "utils".

```
find_package(directxmesh CONFIG REQUIRED COMPONENTS library utils)

target_link_libraries(foo Microsoft::DirectXMesh Microsoft::DirectXMesh::Utilities)
```
