### PR TITLE
Code review for standard library header usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.16")
 endif()
 
 if(MSVC)
-    # Use max Warning Level 
+    # Use max Warning Level
     string(REPLACE "/W3 " "/Wall " CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
     string(REPLACE "/W3 " "/Wall " CMAKE_CXX_FLAGS_DEBUG ${CMAKE_CXX_FLAGS_DEBUG})
     string(REPLACE "/W3 " "/Wall " CMAKE_CXX_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE})
@@ -214,4 +214,3 @@ endif()
 if(BUILD_TOOLS)
   set_property(DIRECTORY PROPERTY VS_STARTUP_PROJECT meshconvert)
 endif()
-

--- a/DirectXMesh/DirectXMesh.h
+++ b/DirectXMesh/DirectXMesh.h
@@ -1,6 +1,6 @@
 //-------------------------------------------------------------------------------------
 // DirectXMesh.h
-//  
+//
 // DirectX Mesh Geometry Library
 //
 // Copyright (c) Microsoft Corporation. All rights reserved.
@@ -11,10 +11,12 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #if !defined(__d3d11_h__) && !defined(__d3d11_x_h__) && !defined(__d3d12_h__) && !defined(__d3d12_x_h__) && !defined(__XBOX_D3D12_X__)
@@ -34,6 +36,7 @@
 #include <DirectXPackedVector.h>
 
 #define DIRECTX_MESH_VERSION 160
+
 
 namespace DirectX
 {

--- a/DirectXMesh/DirectXMeshP.h
+++ b/DirectXMesh/DirectXMeshP.h
@@ -97,6 +97,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cmath>
+#include <cstdlib>
 #include <cstring>
 #include <map>
 #include <string>

--- a/DirectXMesh/DirectXMeshP.h
+++ b/DirectXMesh/DirectXMeshP.h
@@ -1,6 +1,6 @@
 //-------------------------------------------------------------------------------------
 // DirectXMeshP.h
-//  
+//
 // DirectX Mesh Geometry Library
 //
 // Copyright (c) Microsoft Corporation. All rights reserved.
@@ -69,11 +69,11 @@
 #define NOHELP
 #pragma warning(pop)
 
+#include <Windows.h>
+
 #ifndef _WIN32_WINNT_WIN10
 #define _WIN32_WINNT_WIN10 0x0A00
 #endif
-
-#include <Windows.h>
 
 #ifdef _GAMING_XBOX_SCARLETT
 #include <d3d12_xs.h>
@@ -91,19 +91,19 @@
 
 #define _XM_NO_XMVECTOR_OVERLOADS_
 
-#include <DirectXMath.h>
-
-#include <assert.h>
-#include <malloc.h>
+#include "DirectXMesh.h"
 
 #include <array>
 #include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <cstring>
 #include <map>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
 
-#include "DirectXMesh.h"
+#include <malloc.h>
 
 #include "scoped.h"
 

--- a/Meshconvert/Mesh.cpp
+++ b/Meshconvert/Mesh.cpp
@@ -22,6 +22,10 @@
 #pragma warning(pop)
 
 #include "Mesh.h"
+
+#include <cstring>
+#include <utility>
+
 #include "SDKMesh.h"
 
 #include <DirectXPackedVector.h>

--- a/Meshconvert/Mesh.h
+++ b/Meshconvert/Mesh.h
@@ -12,6 +12,7 @@
 
 #include <Windows.h>
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <ostream>

--- a/Meshconvert/Meshconvert.cpp
+++ b/Meshconvert/Meshconvert.cpp
@@ -20,10 +20,10 @@
 #define NOHELP
 #pragma warning(pop)
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <assert.h>
-
+#include <cassert>
+#include <cstddef>
+#include <cstdio>
+#include <cstdlib>
 #include <fstream>
 #include <memory>
 #include <list>


### PR DESCRIPTION
Reviewed all the C++ standard library header usage and normalized usage for improved conformance.

* ``size_t`` requires ``cstddef``
* ``memcpy``, ``memcpy_s`` is officially in ``cstring``
* Use ``cassert`` instead of ``assert.h``
* ``std::move`` is in ``utility``

> The non-standard malloc.h is still being included for ``_aligned_malloc`` / ``_aligned_free``. To be conformant, I should update it to use ``aligned_alloc`` and ``free`` when building for C++17 which is in ``cstdlib``.

Also trimmed trailing whitespace in these files.