### PR TITLE
ConcatenateMesh function

### DIFF
--- a/DirectXMesh/DirectXMesh.h
+++ b/DirectXMesh/DirectXMesh.h
@@ -373,6 +373,15 @@ namespace DirectX
         _In_ std::function<bool __cdecl(uint32_t v0, uint32_t v1)> weldTest);
         // Welds vertices together based on a test function
 
+    HRESULT __cdecl ConcatenateMesh(
+        _In_ size_t nFaces,
+        _In_ size_t nVerts,
+        _Out_writes_(nFaces) uint32_t* faceRemap,
+        _Out_writes_(nVerts) uint32_t* vertexRemap,
+        _Inout_ size_t& totalFaces,
+        _Inout_ size_t& totalVerts) noexcept;
+        // Merge meshes together
+
     //---------------------------------------------------------------------------------
     // Mesh Optimization
 

--- a/DirectXMesh/DirectXMeshConcat.cpp
+++ b/DirectXMesh/DirectXMeshConcat.cpp
@@ -1,0 +1,60 @@
+//-------------------------------------------------------------------------------------
+// DirectXMeshConcat.cpp
+//  
+// DirectX Mesh Geometry Library - Concatenate mesh
+//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//
+// http://go.microsoft.com/fwlink/?LinkID=324981
+//-------------------------------------------------------------------------------------
+
+#include "DirectXMeshP.h"
+
+using namespace DirectX;
+
+//=====================================================================================
+// Entry-points
+//=====================================================================================
+
+_Use_decl_annotations_
+HRESULT __cdecl DirectX::ConcatenateMesh(
+    size_t nFaces,
+    size_t nVerts,
+    uint32_t* faceDestMap,
+    uint32_t* vertexDestMap,
+    size_t& totalFaces,
+    size_t& totalVerts) noexcept
+{
+    if (!nFaces || !nVerts || !faceDestMap || !vertexDestMap)
+        return E_INVALIDARG;
+
+    if (nVerts >= UINT32_MAX)
+        return E_INVALIDARG;
+
+    if ((uint64_t(nFaces) * 3) >= UINT32_MAX)
+        return HRESULT_E_ARITHMETIC_OVERFLOW;
+
+    uint64_t newFaceCount = uint64_t(totalFaces) + nFaces;
+    uint64_t newVertCount = uint64_t(totalVerts) + nVerts;
+
+    if (newFaceCount >= UINT32_MAX || newVertCount >= UINT32_MAX)
+        return E_FAIL;
+
+    auto baseFace = static_cast<uint32_t>(totalFaces);
+    for (uint32_t j = 0; j < nFaces; ++j)
+    {
+        faceDestMap[j] = baseFace + j;
+    }
+
+    auto baseVert = static_cast<uint32_t>(totalVerts);
+    for (uint32_t j = 0; j < nVerts; ++j)
+    {
+        vertexDestMap[j] = baseVert + j;
+    }
+
+    totalFaces = static_cast<size_t>(newFaceCount);
+    totalVerts = static_cast<size_t>(newVertCount);
+
+    return S_OK;
+}

--- a/DirectXMesh/DirectXMesh_Desktop_2017.vcxproj
+++ b/DirectXMesh/DirectXMesh_Desktop_2017.vcxproj
@@ -311,6 +311,7 @@
   </ItemDefinitionGroup>
   <ItemGroup />
   <ItemGroup>
+    <ClCompile Include="DirectXMeshConcat.cpp" />
     <ClCompile Include="DirectXMeshletGenerator.cpp" />
     <ClCompile Include="DirectXMeshWeldVertices.cpp" />
     <CLInclude Include="DirectXMesh.h" />

--- a/DirectXMesh/DirectXMesh_Desktop_2017.vcxproj.filters
+++ b/DirectXMesh/DirectXMesh_Desktop_2017.vcxproj.filters
@@ -65,6 +65,9 @@
     <ClCompile Include="DirectXMeshletGenerator.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="DirectXMeshConcat.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <CLInclude Include="DirectXMeshP.h">

--- a/DirectXMesh/DirectXMesh_Desktop_2017_Win10.vcxproj
+++ b/DirectXMesh/DirectXMesh_Desktop_2017_Win10.vcxproj
@@ -457,6 +457,7 @@
   </ItemDefinitionGroup>
   <ItemGroup />
   <ItemGroup>
+    <ClCompile Include="DirectXMeshConcat.cpp" />
     <ClCompile Include="DirectXMeshletGenerator.cpp" />
     <ClCompile Include="DirectXMeshWeldVertices.cpp" />
     <CLInclude Include="DirectXMesh.h" />

--- a/DirectXMesh/DirectXMesh_Desktop_2017_Win10.vcxproj.filters
+++ b/DirectXMesh/DirectXMesh_Desktop_2017_Win10.vcxproj.filters
@@ -65,6 +65,9 @@
     <ClCompile Include="DirectXMeshletGenerator.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="DirectXMeshConcat.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <CLInclude Include="DirectXMeshP.h">

--- a/DirectXMesh/DirectXMesh_Desktop_2019.vcxproj
+++ b/DirectXMesh/DirectXMesh_Desktop_2019.vcxproj
@@ -317,6 +317,7 @@
   </ItemDefinitionGroup>
   <ItemGroup />
   <ItemGroup>
+    <ClCompile Include="DirectXMeshConcat.cpp" />
     <ClCompile Include="DirectXMeshletGenerator.cpp" />
     <ClCompile Include="DirectXMeshWeldVertices.cpp" />
     <CLInclude Include="DirectXMesh.h" />

--- a/DirectXMesh/DirectXMesh_Desktop_2019.vcxproj.filters
+++ b/DirectXMesh/DirectXMesh_Desktop_2019.vcxproj.filters
@@ -65,6 +65,9 @@
     <ClCompile Include="DirectXMeshletGenerator.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="DirectXMeshConcat.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <CLInclude Include="DirectXMeshP.h">

--- a/DirectXMesh/DirectXMesh_Desktop_2019_Win10.vcxproj
+++ b/DirectXMesh/DirectXMesh_Desktop_2019_Win10.vcxproj
@@ -463,6 +463,7 @@
   </ItemDefinitionGroup>
   <ItemGroup />
   <ItemGroup>
+    <ClCompile Include="DirectXMeshConcat.cpp" />
     <ClCompile Include="DirectXMeshletGenerator.cpp" />
     <ClCompile Include="DirectXMeshWeldVertices.cpp" />
     <CLInclude Include="DirectXMesh.h" />

--- a/DirectXMesh/DirectXMesh_Desktop_2019_Win10.vcxproj.filters
+++ b/DirectXMesh/DirectXMesh_Desktop_2019_Win10.vcxproj.filters
@@ -65,6 +65,9 @@
     <ClCompile Include="DirectXMeshletGenerator.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="DirectXMeshConcat.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <CLInclude Include="DirectXMeshP.h">

--- a/DirectXMesh/DirectXMesh_GDK_2017.vcxproj
+++ b/DirectXMesh/DirectXMesh_GDK_2017.vcxproj
@@ -424,6 +424,7 @@
   <ItemGroup>
     <None Include="..\README.md" />
     <None Include="DirectXMesh.inl" />
+    <None Include="DirectXMeshConcat.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="DirectXMeshAdjacency.cpp" />

--- a/DirectXMesh/DirectXMesh_GDK_2017.vcxproj.filters
+++ b/DirectXMesh/DirectXMesh_GDK_2017.vcxproj.filters
@@ -28,6 +28,9 @@
     <None Include="..\README.md">
       <Filter>Source Files</Filter>
     </None>
+    <None Include="DirectXMeshConcat.cpp">
+      <Filter>Source Files</Filter>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="DirectXMeshUtil.cpp">

--- a/DirectXMesh/DirectXMesh_GDK_2019.vcxproj
+++ b/DirectXMesh/DirectXMesh_GDK_2019.vcxproj
@@ -428,6 +428,7 @@
   <ItemGroup>
     <ClCompile Include="DirectXMeshAdjacency.cpp" />
     <ClCompile Include="DirectXMeshClean.cpp" />
+    <ClCompile Include="DirectXMeshConcat.cpp" />
     <ClCompile Include="DirectXMeshGSAdjacency.cpp" />
     <ClCompile Include="DirectXMeshletGenerator.cpp" />
     <ClCompile Include="DirectXMeshNormals.cpp" />

--- a/DirectXMesh/DirectXMesh_GDK_2019.vcxproj.filters
+++ b/DirectXMesh/DirectXMesh_GDK_2019.vcxproj.filters
@@ -73,5 +73,8 @@
     <ClCompile Include="DirectXMeshletGenerator.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="DirectXMeshConcat.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/DirectXMesh/DirectXMesh_Windows10_2017.vcxproj
+++ b/DirectXMesh/DirectXMesh_Windows10_2017.vcxproj
@@ -37,6 +37,7 @@
   <ItemGroup>
     <ClCompile Include="DirectXMeshAdjacency.cpp" />
     <ClCompile Include="DirectXMeshClean.cpp" />
+    <ClCompile Include="DirectXMeshConcat.cpp" />
     <ClCompile Include="DirectXMeshGSAdjacency.cpp" />
     <ClCompile Include="DirectXMeshletGenerator.cpp" />
     <ClCompile Include="DirectXMeshNormals.cpp" />

--- a/DirectXMesh/DirectXMesh_Windows10_2017.vcxproj.filters
+++ b/DirectXMesh/DirectXMesh_Windows10_2017.vcxproj.filters
@@ -46,6 +46,9 @@
     <ClCompile Include="DirectXMeshletGenerator.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="DirectXMeshConcat.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="DirectXMesh.h">

--- a/DirectXMesh/DirectXMesh_Windows10_2019.vcxproj
+++ b/DirectXMesh/DirectXMesh_Windows10_2019.vcxproj
@@ -37,6 +37,7 @@
   <ItemGroup>
     <ClCompile Include="DirectXMeshAdjacency.cpp" />
     <ClCompile Include="DirectXMeshClean.cpp" />
+    <ClCompile Include="DirectXMeshConcat.cpp" />
     <ClCompile Include="DirectXMeshGSAdjacency.cpp" />
     <ClCompile Include="DirectXMeshletGenerator.cpp" />
     <ClCompile Include="DirectXMeshNormals.cpp" />

--- a/DirectXMesh/DirectXMesh_Windows10_2019.vcxproj.filters
+++ b/DirectXMesh/DirectXMesh_Windows10_2019.vcxproj.filters
@@ -46,6 +46,9 @@
     <ClCompile Include="DirectXMeshletGenerator.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="DirectXMeshConcat.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="DirectXMesh.h">

--- a/DirectXMesh/DirectXMesh_XboxOneXDK_2017.vcxproj
+++ b/DirectXMesh/DirectXMesh_XboxOneXDK_2017.vcxproj
@@ -25,6 +25,7 @@
   <ItemGroup>
     <ClCompile Include="DirectXMeshAdjacency.cpp" />
     <ClCompile Include="DirectXMeshClean.cpp" />
+    <ClCompile Include="DirectXMeshConcat.cpp" />
     <ClCompile Include="DirectXMeshGSAdjacency.cpp" />
     <ClCompile Include="DirectXMeshletGenerator.cpp" />
     <ClCompile Include="DirectXMeshNormals.cpp" />

--- a/DirectXMesh/DirectXMesh_XboxOneXDK_2017.vcxproj.filters
+++ b/DirectXMesh/DirectXMesh_XboxOneXDK_2017.vcxproj.filters
@@ -72,5 +72,8 @@
     <ClCompile Include="DirectXMeshletGenerator.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="DirectXMeshConcat.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Helper for generating mappings when merging meshes.

> Note that these remaps are the *inverse* of the other library remaps. These are ``newLoc = map[oldLoc]`` which is much easier to use when constructing merged meshes. The 'normal' style of maps would require a pair to indicate mesh and oldLoc.