### PR TITLE
FlexibleVertexFormat.h header added to Utilities

### DIFF
--- a/.nuget/directxmesh_desktop_2017.nuspec
+++ b/.nuget/directxmesh_desktop_2017.nuspec
@@ -26,7 +26,7 @@ DirectXMesh, a shared source library for performing various geometry content pro
         <file target="include" src="DirectXMesh\DirectXMesh.h" />
         <file target="include" src="DirectXMesh\DirectXMesh.inl" />
 
-        <file target="include" src="Utilities\WaveFrontReader.h" />
+        <file target="include" src="Utilities\*.h" />
 
         <file target="native\lib\Win32\Debug" src="DirectXMesh\Bin\Desktop_2017\Win32\Debug\*.lib" />
         <file target="native\lib\Win32\Debug" src="DirectXMesh\Bin\Desktop_2017\Win32\Debug\*.pdb" />

--- a/.nuget/directxmesh_desktop_win10.nuspec
+++ b/.nuget/directxmesh_desktop_win10.nuspec
@@ -26,7 +26,7 @@ DirectXMesh, a shared source library for performing various geometry content pro
         <file target="include" src="DirectXMesh\DirectXMesh.h" />
         <file target="include" src="DirectXMesh\DirectXMesh.inl" />
 
-        <file target="include" src="Utilities\WaveFrontReader.h" />
+        <file target="include" src="Utilities\*.h" />
 
         <file target="native\lib\Win32\Debug" src="DirectXMesh\Bin\Desktop_2017_Win10\Win32\Debug\*.lib" />
         <file target="native\lib\Win32\Debug" src="DirectXMesh\Bin\Desktop_2017_Win10\Win32\Debug\*.pdb" />

--- a/.nuget/directxmesh_uwp.nuspec
+++ b/.nuget/directxmesh_uwp.nuspec
@@ -26,7 +26,7 @@ DirectXMesh, a shared source library for performing various geometry content pro
         <file target="include" src="DirectXMesh\DirectXMesh.h" />
         <file target="include" src="DirectXMesh\DirectXMesh.inl" />
 
-        <file target="include" src="Utilities\WaveFrontReader.h" />
+        <file target="include" src="Utilities\*.h" />
 
         <file target="native\lib\ARM\Debug" src="DirectXMesh\Bin\Windows10_2017\ARM\Debug\*.lib" />
         <file target="native\lib\ARM\Debug" src="DirectXMesh\Bin\Windows10_2017\ARM\Debug\*.pdb" />

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ endif()
 
 #--- Utilities
 set(UTILS_HEADERS
+    Utilities/FlexibleVertexFormat.h
     Utilities/WaveFrontReader.h)
 
 add_library(Utilities INTERFACE)

--- a/Utilities/FlexibleVertexFormat.h
+++ b/Utilities/FlexibleVertexFormat.h
@@ -1,0 +1,75 @@
+//--------------------------------------------------------------------------------------
+// File: FlexibleVertexFormat.h
+//
+// Helpers for legacy Direct3D 9 era FVF codes and vertex decls
+//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//
+// http://go.microsoft.com/fwlink/?LinkID=324981
+//--------------------------------------------------------------------------------------
+
+#pragma once
+
+#include <d3d9.h>
+
+#include <cstdint>
+
+namespace FVF
+{
+    inline size_t ComputeFVFVertexSize(uint32_t fvfCode)
+    {
+        size_t vertexSize = 0;
+
+        switch (fvfCode & D3DFVF_POSITION_MASK)
+        {
+        case D3DFVF_XYZ:    vertexSize = 3 * sizeof(float); break;
+        case D3DFVF_XYZRHW: vertexSize = 4 * sizeof(float); break;
+        case D3DFVF_XYZB1:  vertexSize = 4 * sizeof(float); break;
+        case D3DFVF_XYZB2:  vertexSize = 5 * sizeof(float); break;
+        case D3DFVF_XYZB3:  vertexSize = 6 * sizeof(float); break;
+        case D3DFVF_XYZB4:  vertexSize = 7 * sizeof(float); break;
+        case D3DFVF_XYZB5:  vertexSize = 8 * sizeof(float); break;
+        default:
+            return 0;
+        }
+
+        if (fvfCode & D3DFVF_NORMAL)
+            vertexSize += 3 * sizeof(float);
+
+        if (fvfCode & D3DFVF_PSIZE)
+            vertexSize += sizeof(uint32_t);
+
+        if (fvfCode & D3DFVF_DIFFUSE)
+            vertexSize += sizeof(uint32_t);
+
+        if (fvfCode & D3DFVF_SPECULAR)
+            vertexSize += sizeof(uint32_t);
+
+        // Texture coordinates
+        size_t numCoords = (((fvfCode)&D3DFVF_TEXCOUNT_MASK) >> D3DFVF_TEXCOUNT_SHIFT);
+        uint32_t textureFormats = fvfCode >> 16u;
+
+        if (textureFormats)
+        {
+            for (size_t i = 0; i < numCoords; i++)
+            {
+                switch (textureFormats & 3)
+                {
+                case 0: vertexSize += 2 * sizeof(float); break;
+                case 1: vertexSize += 3 * sizeof(float); break;
+                case 2: vertexSize += 4 * sizeof(float); break;
+                case 3: vertexSize += 1 * sizeof(float); break;
+                }
+
+                textureFormats >>= 2;
+            }
+        }
+        else
+        {
+            vertexSize += numCoords * (2 * sizeof(float));
+        }
+
+        return vertexSize;
+    }
+}

--- a/Utilities/FlexibleVertexFormat.h
+++ b/Utilities/FlexibleVertexFormat.h
@@ -700,24 +700,32 @@ namespace FVF
                         weights = pCurrent->Type - D3DDECLTYPE_FLOAT1 + 1;
                         ++pCurrent;
                     }
+                    else
+                    {
+                        return 0;
+                    }
                 }
 
-                if ((pCurrent->Usage == D3DDECLUSAGE_BLENDINDICES)
-                    && (pCurrent->Type == D3DDECLTYPE_UBYTE4))
+                if (pCurrent->Usage == D3DDECLUSAGE_BLENDINDICES)
                 {
-                    fvfCode |= D3DFVF_LASTBETA_UBYTE4;
+                    if (pCurrent->Type == D3DDECLTYPE_UBYTE4)
+                    {
+                        fvfCode |= D3DFVF_LASTBETA_UBYTE4;
 
-                    ++weights;
-                    ++pCurrent;
-                }
+                        ++weights;
+                        ++pCurrent;
+                    }
+                    else if (pCurrent->Type == D3DDECLTYPE_D3DCOLOR)
+                    {
+                        fvfCode |= D3DFVF_LASTBETA_D3DCOLOR;
 
-                if ((pCurrent->Usage == D3DDECLUSAGE_BLENDINDICES)
-                    && (pCurrent->Type == D3DDECLTYPE_D3DCOLOR))
-                {
-                    fvfCode |= D3DFVF_LASTBETA_D3DCOLOR;
-
-                    ++weights;
-                    ++pCurrent;
+                        ++weights;
+                        ++pCurrent;
+                    }
+                    else
+                    {
+                        return 0;
+                    }
                 }
 
                 switch (weights)
@@ -895,30 +903,38 @@ namespace FVF
                             return 0;
                         ++pCurrent;
                     }
+                    else
+                    {
+                        return 0;
+                    }
                 }
 
-                if ((pCurrent->Usage == D3DDECLUSAGE_BLENDINDICES)
-                    && (pCurrent->Type == D3DDECLTYPE_UBYTE4))
+                if (pCurrent->Usage == D3DDECLUSAGE_BLENDINDICES)
                 {
-                    fvfCode |= D3DFVF_LASTBETA_UBYTE4;
+                    if (pCurrent->Type == D3DDECLTYPE_UBYTE4)
+                    {
+                        fvfCode |= D3DFVF_LASTBETA_UBYTE4;
 
-                    ++weights;
-                    ++count;
-                    if (count > maxDeclLength)
+                        ++weights;
+                        ++count;
+                        if (count > maxDeclLength)
+                            return 0;
+                        ++pCurrent;
+                    }
+                    else if (pCurrent->Type == D3DDECLTYPE_D3DCOLOR)
+                    {
+                        fvfCode |= D3DFVF_LASTBETA_D3DCOLOR;
+
+                        ++weights;
+                        ++count;
+                        if (count > maxDeclLength)
+                            return 0;
+                        ++pCurrent;
+                    }
+                    else
+                    {
                         return 0;
-                    ++pCurrent;
-                }
-
-                if ((pCurrent->Usage == D3DDECLUSAGE_BLENDINDICES)
-                    && (pCurrent->Type == D3DDECLTYPE_D3DCOLOR))
-                {
-                    fvfCode |= D3DFVF_LASTBETA_D3DCOLOR;
-
-                    ++weights;
-                    ++count;
-                    if (count > maxDeclLength)
-                        return 0;
-                    ++pCurrent;
+                    }
                 }
 
                 switch (weights)

--- a/Utilities/FlexibleVertexFormat.h
+++ b/Utilities/FlexibleVertexFormat.h
@@ -498,10 +498,144 @@ namespace FVF
 
 #ifdef __d3d12_h__
     _Success_(return != false)
-        inline bool CreateInputLayoutFromFVF(uint32_t fvfCode, std::vector<D3D12_INPUT_ELEMENT_DESC>& decl)
+        inline bool CreateInputLayoutFromFVF(uint32_t fvfCode, std::vector<D3D12_INPUT_ELEMENT_DESC>& il)
     {
-        // TODO -
-        return false;
+        static constexpr DXGI_FORMAT s_blendFormats[] =
+        {
+            DXGI_FORMAT_R32_FLOAT,
+            DXGI_FORMAT_R32G32_FLOAT,
+            DXGI_FORMAT_R32G32B32_FLOAT,
+            DXGI_FORMAT_R32G32B32A32_FLOAT,
+        };
+
+        static constexpr DXGI_FORMAT s_texCoordFormats[] =
+        {
+            DXGI_FORMAT_R32G32_FLOAT,
+            DXGI_FORMAT_R32G32B32_FLOAT,
+            DXGI_FORMAT_R32G32B32A32_FLOAT,
+            DXGI_FORMAT_R32_FLOAT
+        };
+
+        il.clear();
+
+        if ((fvfCode & ((D3DFVF_RESERVED0 | D3DFVF_RESERVED2) & ~D3DFVF_POSITION_MASK)) != 0)
+            return false;
+
+        uint32_t nTexCoords = (fvfCode & D3DFVF_TEXCOUNT_MASK) >> D3DFVF_TEXCOUNT_SHIFT;
+        if (nTexCoords > 8)
+            return false;
+
+        switch (fvfCode & D3DFVF_POSITION_MASK)
+        {
+        case 0:
+            break;
+
+        case D3DFVF_XYZRHW:
+        case D3DFVF_XYZW:
+            il.emplace_back(
+                D3D12_INPUT_ELEMENT_DESC{ "SV_Position", 0, DXGI_FORMAT_R32G32B32A32_FLOAT,
+                    0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
+            );
+            break;
+
+        default:
+            il.emplace_back(
+                D3D12_INPUT_ELEMENT_DESC{ "SV_Position", 0, DXGI_FORMAT_R32G32B32_FLOAT,
+                    0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
+            );
+            break;
+        }
+
+        size_t weights = 0;
+        switch (fvfCode & D3DFVF_POSITION_MASK)
+        {
+        case D3DFVF_XYZB1: weights = 1; break;
+        case D3DFVF_XYZB2: weights = 2; break;
+        case D3DFVF_XYZB3: weights = 3; break;
+        case D3DFVF_XYZB4: weights = 4; break;
+        case D3DFVF_XYZB5: weights = 5; break;
+        }
+
+        if (weights > 0)
+        {
+            if (fvfCode & (D3DFVF_LASTBETA_UBYTE4 | D3DFVF_LASTBETA_D3DCOLOR))
+            {
+                // subtract one for where the blendindices were
+                if (weights > 1)
+                {
+                    il.emplace_back(
+                        D3D12_INPUT_ELEMENT_DESC{ "BLENDWEIGHT", 0, s_blendFormats[weights - 2],
+                        0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
+                    );
+                }
+
+                il.emplace_back(
+                    D3D12_INPUT_ELEMENT_DESC{ "BLENDINDICES", 0,
+                    (fvfCode & D3DFVF_LASTBETA_UBYTE4) ? DXGI_FORMAT_R8G8B8A8_UNORM : DXGI_FORMAT_B8G8R8A8_UNORM,
+                    0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
+                );
+            }
+            else if (weights == 5)
+            {
+                // D3DFVF_XYZB5 is only supported when the 5th beta is D3DFVF_LASTBETA_UBYTE4/D3DCOLOR
+                il.clear();
+                return false;
+            }
+            else
+            {
+                il.emplace_back(
+                    D3D12_INPUT_ELEMENT_DESC{ "BLENDWEIGHT", 0, s_blendFormats[weights - 1],
+                    0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
+                );
+            }
+        }
+
+        if (fvfCode & D3DFVF_NORMAL)
+        {
+            il.emplace_back(
+                D3D12_INPUT_ELEMENT_DESC{ "NORMAL", 0, DXGI_FORMAT_R32G32B32_FLOAT,
+                    0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
+            );
+        }
+
+        if (fvfCode & D3DFVF_PSIZE)
+        {
+            il.emplace_back(
+                D3D12_INPUT_ELEMENT_DESC{ "PSIZE", 0, DXGI_FORMAT_R32_FLOAT,
+                    0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
+            );
+        }
+
+        if (fvfCode & D3DFVF_DIFFUSE)
+        {
+            il.emplace_back(
+                D3D12_INPUT_ELEMENT_DESC{ "COLOR", 0, DXGI_FORMAT_B8G8R8A8_UNORM,
+                    0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
+            );
+        }
+
+        if (fvfCode & D3DFVF_SPECULAR)
+        {
+            il.emplace_back(
+                D3D12_INPUT_ELEMENT_DESC{ "COLOR", 1, DXGI_FORMAT_B8G8R8A8_UNORM,
+                    0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
+            );
+        }
+
+        if (nTexCoords > 0)
+        {
+            for (uint32_t t = 0; t < nTexCoords; ++t)
+            {
+                size_t index = (fvfCode >> (16 + t * 2)) & 0x3;
+                il.emplace_back(
+                    D3D12_INPUT_ELEMENT_DESC{ "TEXCOORD", static_cast<UINT>(t),
+                        s_texCoordFormats[index],
+                        0, D3D12_APPEND_ALIGNED_ELEMENT, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
+                );
+            }
+        }
+
+        return true;
     }
 #endif // __d3d12_h__
 

--- a/Utilities/FlexibleVertexFormat.h
+++ b/Utilities/FlexibleVertexFormat.h
@@ -47,6 +47,10 @@ namespace FVF
         if ((fvfCode & ((D3DFVF_RESERVED0 | D3DFVF_RESERVED2) & ~D3DFVF_POSITION_MASK)) != 0)
             return 0;
 
+        size_t numCoords = (fvfCode & D3DFVF_TEXCOUNT_MASK) >> D3DFVF_TEXCOUNT_SHIFT;
+        if (numCoords > 8)
+            return 0;
+
         size_t vertexSize = 0;
 
         switch (fvfCode & D3DFVF_POSITION_MASK)
@@ -80,7 +84,6 @@ namespace FVF
             vertexSize += sizeof(uint32_t);
 
         // Texture coordinates
-        size_t numCoords = (fvfCode & D3DFVF_TEXCOUNT_MASK) >> D3DFVF_TEXCOUNT_SHIFT;
         uint32_t textureFormats = fvfCode >> 16u;
 
         if (textureFormats)
@@ -108,7 +111,7 @@ namespace FVF
 
     inline size_t ComputeVertexSize(const D3DVERTEXELEMENT9* pDecl, uint32_t stream)
     {
-        if (!pDecl)
+        if (!pDecl || stream >= 16u /*D3D10_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT*/)
             return 0;
 
         size_t currentSize = 0;
@@ -144,7 +147,7 @@ namespace FVF
     inline size_t ComputeVertexSize(
         _In_reads_(maxDeclLength) const D3DVERTEXELEMENT9* pDecl, size_t maxDeclLength, uint32_t stream)
     {
-        if (!pDecl)
+        if (!pDecl || stream >= 16u /*D3D10_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT*/)
             return 0;
 
         if (maxDeclLength > MAXD3DDECLLENGTH + 1)
@@ -181,10 +184,13 @@ namespace FVF
 
     inline size_t GetDeclLength(const D3DVERTEXELEMENT9* pDecl)
     {
+        if (!pDecl)
+            return 0;
+
         size_t length = 0;
         while (pDecl->Stream != 0xFF)
         {
-            if (length > MAXD3DDECLLENGTH)
+            if (length >= MAXD3DDECLLENGTH)
                 return 0;
 
             ++pDecl;
@@ -337,6 +343,24 @@ namespace FVF
 
         return true;
     }
+
+#ifdef __d3d11_h__
+    _Success_(return != false)
+        inline bool CreateInputLayoutFromFVF(uint32_t fvfCode, std::vector<D3D11_INPUT_ELEMENT_DESC>& decl)
+    {
+        // TODO -
+        return false;
+    }
+#endif
+
+#ifdef __d3d12_h__
+    _Success_(return != false)
+        inline bool CreateInputLayoutFromFVF(uint32_t fvfCode, std::vector<D3D12_INPUT_ELEMENT_DESC>& decl)
+    {
+        // TODO -
+        return false;
+    }
+#endif
 
     inline uint32_t ComputeFVF(const D3DVERTEXELEMENT9* pDecl)
     {

--- a/Utilities/FlexibleVertexFormat.h
+++ b/Utilities/FlexibleVertexFormat.h
@@ -42,6 +42,14 @@ namespace FVF
 
     static_assert(std::size(g_declTypeSizes) == D3DDECLTYPE_UNUSED, "Mismatch of array size");
 
+    constexpr size_t g_texCoordSizes[] =
+    {
+        2 * sizeof(float),
+        3 * sizeof(float),
+        4 * sizeof(float),
+        sizeof(float)
+    };
+
     inline size_t ComputeVertexSize(uint32_t fvfCode)
     {
         if ((fvfCode & ((D3DFVF_RESERVED0 | D3DFVF_RESERVED2) & ~D3DFVF_POSITION_MASK)) != 0)
@@ -327,13 +335,13 @@ namespace FVF
         {
             for (uint32_t t = 0; t < nTexCoords; ++t)
             {
-                size_t texCoordSize = g_declTypeSizes[(fvfCode >> (16 + t * 2)) & 0x3];
+                size_t texCoordSize = g_texCoordSizes[(fvfCode >> (16 + t * 2)) & 0x3];
 
                 // D3DDECLTYPE_FLOAT1 = 0, D3DDECLTYPE_FLOAT4 = 3
                 decl.emplace_back(
                     D3DVERTEXELEMENT9{ 0, static_cast<WORD>(offset),
                         static_cast<BYTE>(texCoordSize / sizeof(float) - 1),
-                        D3DDECLMETHOD_DEFAULT, D3DDECLUSAGE_TEXCOORD, 1 }
+                        D3DDECLMETHOD_DEFAULT, D3DDECLUSAGE_TEXCOORD, static_cast<BYTE>(t) }
                 );
                 offset += texCoordSize;
             }


### PR DESCRIPTION
This PR adds a new utility header to the DirectXMesh repo. This contains helper functions for working with Direct3D 9 legacy [FVF codes](https://docs.microsoft.com/en-us/windows/win32/direct3d9/fixed-function-fvf-codes) and Direct3D 9 decls. This is useful for tools parsing through older resources, Xfiles, etc. Also added secure versions of two functions that really need bounds to be SAL annotatable.

> This header does not require any legacy DirectX SDK headers, but will only build for the "Win32 Desktop" partition because it uses ``d3d9.h`` (i.e. it's not usable in UWP apps. If that's an issue, please note that in this review).