### PR TITLE
Fixed meshlet verticies overflow in case degenerate triangle is passed

### DIFF
--- a/DirectXMesh/DirectXMeshletGenerator.cpp
+++ b/DirectXMesh/DirectXMeshletGenerator.cpp
@@ -180,6 +180,11 @@ namespace
         if (meshlet.PrimitiveIndices.size() >= maxPrims)
             return false;
 
+        // Cull degenerate triangle and return success
+        // newCount calculation will break if such triangle is passed
+        if (tri[0] == tri[1] || tri[1] == tri[2] || tri[0] == tri[2])
+            return true;
+
         uint32_t indices[3] = { uint32_t(-1), uint32_t(-1), uint32_t(-1) };
         uint8_t newCount = 3;
 

--- a/DirectXMesh/DirectXMeshletGenerator.cpp
+++ b/DirectXMesh/DirectXMeshletGenerator.cpp
@@ -172,6 +172,11 @@ namespace
         _In_reads_(3) const T* tri,
         InlineMeshlet<T>& meshlet)
     {
+        // Cull degenerate triangle and return success
+        // newCount calculation will break if such triangle is passed
+        if (tri[0] == tri[1] || tri[1] == tri[2] || tri[0] == tri[2])
+            return true;
+        
         // Are we already full of vertices?
         if (meshlet.UniqueVertexIndices.size() >= maxVerts)
             return false;
@@ -179,11 +184,6 @@ namespace
         // Are we full, or can we store an additional primitive?
         if (meshlet.PrimitiveIndices.size() >= maxPrims)
             return false;
-
-        // Cull degenerate triangle and return success
-        // newCount calculation will break if such triangle is passed
-        if (tri[0] == tri[1] || tri[1] == tri[2] || tri[0] == tri[2])
-            return true;
 
         uint32_t indices[3] = { uint32_t(-1), uint32_t(-1), uint32_t(-1) };
         uint8_t newCount = 3;


### PR DESCRIPTION
If triangle, that have 2 identical indices is ever passed to meshlet generation, it may result in generation of meshlet with vertex count higher than allowed (maxVerts parameter).
If such triangle is added, UniqueVertexIndices will have 2 identical indices.
It's a problem for code calculating whether triangle fit into meshlet.
newCount may be decremented twice for each vertex instead of once,
resulting in lower newCount than it will actually be added later.
So I propose to just cull degenerate triangles.
That will both fix the issue and result in better generated meshlets in cases input geometry have degenerate triangles.