### PR TITLE
Follow the Rule Of Zero in VBReader and VBWriter classes

### DIFF
--- a/DirectXMesh/DirectXMesh.h
+++ b/DirectXMesh/DirectXMesh.h
@@ -92,13 +92,6 @@ namespace DirectX
     {
     public:
         VBReader() noexcept(false);
-        VBReader(VBReader&& moveFrom) noexcept;
-        VBReader& operator= (VBReader&& moveFrom) noexcept;
-
-        VBReader(VBReader const&) = delete;
-        VBReader& operator= (VBReader const&) = delete;
-
-        ~VBReader();
 
     #if defined(__d3d11_h__) || defined(__d3d11_x_h__)
         HRESULT __cdecl Initialize(_In_reads_(nDecl) const D3D11_INPUT_ELEMENT_DESC* vbDecl, _In_ size_t nDecl);
@@ -148,13 +141,6 @@ namespace DirectX
     {
     public:
         VBWriter() noexcept(false);
-        VBWriter(VBWriter&& moveFrom) noexcept;
-        VBWriter& operator= (VBWriter&& moveFrom) noexcept;
-
-        VBWriter(VBWriter const&) = delete;
-        VBWriter& operator= (VBWriter const&) = delete;
-
-        ~VBWriter();
 
     #if defined(__d3d11_h__) || defined(__d3d11_x_h__)
         HRESULT __cdecl Initialize(_In_reads_(nDecl) const D3D11_INPUT_ELEMENT_DESC* vbDecl, _In_ size_t nDecl);

--- a/DirectXMesh/DirectXMeshVBReader.cpp
+++ b/DirectXMesh/DirectXMeshVBReader.cpp
@@ -654,28 +654,6 @@ VBReader::VBReader() noexcept(false)
 {
 }
 
-
-// Move constructor.
-VBReader::VBReader(VBReader&& moveFrom) noexcept
-    : pImpl(std::move(moveFrom.pImpl))
-{
-}
-
-
-// Move assignment.
-VBReader& VBReader::operator= (VBReader&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
-
-
-// Public destructor.
-VBReader::~VBReader()
-{
-}
-
-
 //-------------------------------------------------------------------------------------
 #if defined(__d3d11_h__) || defined(__d3d11_x_h__)
 _Use_decl_annotations_

--- a/DirectXMesh/DirectXMeshVBWriter.cpp
+++ b/DirectXMesh/DirectXMeshVBWriter.cpp
@@ -652,28 +652,6 @@ VBWriter::VBWriter() noexcept(false)
 {
 }
 
-
-// Move constructor.
-VBWriter::VBWriter(VBWriter&& moveFrom) noexcept
-    : pImpl(std::move(moveFrom.pImpl))
-{
-}
-
-
-// Move assignment.
-VBWriter& VBWriter::operator= (VBWriter&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
-
-
-// Public destructor.
-VBWriter::~VBWriter()
-{
-}
-
-
 //-------------------------------------------------------------------------------------
 #if defined(__d3d11_h__) || defined(__d3d11_x_h__)
 _Use_decl_annotations_


### PR DESCRIPTION
Member `std::unique_ptr` already takes care of resource management.
https://en.cppreference.com/w/cpp/language/rule_of_three#Rule_of_zero