### PR TITLE
Remove inline specifier from constexpr function

### DIFF
--- a/DirectXMesh/DirectXMesh.inl
+++ b/DirectXMesh/DirectXMesh.inl
@@ -29,7 +29,7 @@ inline bool __cdecl IsValidVB(DXGI_FORMAT fmt) noexcept
 }
 
 _Use_decl_annotations_
-constexpr inline bool __cdecl IsValidIB(DXGI_FORMAT fmt) noexcept
+constexpr bool __cdecl IsValidIB(DXGI_FORMAT fmt) noexcept
 {
     return (fmt == DXGI_FORMAT_R32_UINT || fmt == DXGI_FORMAT_R16_UINT) != 0;
 }


### PR DESCRIPTION
According to the standard, constexpr functions are also inline.