### PR TITLE
Use map instead of multimap in WaveFrontReader.h

### DIFF
--- a/Utilities/WaveFrontReader.h
+++ b/Utilities/WaveFrontReader.h
@@ -685,20 +685,15 @@ public:
     DirectX::BoundingBox    bounds;
 
 private:
-    using VertexCache = std::unordered_multimap<uint32_t, uint32_t>;
+    using VertexCache = std::unordered_map<uint32_t, uint32_t>;
 
     uint32_t AddVertex(uint32_t hash, const Vertex* pVertex, VertexCache& cache)
     {
-        auto f = cache.equal_range(hash);
+        auto f = cache.find(hash);
 
-        for (auto it = f.first; it != f.second; ++it)
+        if (f != cache.end())
         {
-            auto& tv = vertices[it->second];
-
-            if (0 == memcmp(pVertex, &tv, sizeof(Vertex)))
-            {
-                return it->second;
-            }
+            return f->second;
         }
 
         auto index = static_cast<uint32_t>(vertices.size());


### PR DESCRIPTION
If two vertices have the same vertexIdx, the second one will just not insert. One index will never map to different vertices.

In other words, once entered the loop at line 694, line 700 will always return - so no need to use a multimap.