### PR TITLE
Add Spectre-mitigated libraries to the NuGet

### DIFF
--- a/.nuget/directxmesh_desktop_2019.nuspec
+++ b/.nuget/directxmesh_desktop_2019.nuspec
@@ -33,14 +33,26 @@ DirectXMesh, a shared source library for performing various geometry content pro
         <file target="native\lib\x86\Debug" src="DirectXMesh\Bin\Desktop_2019\Win32\Debug\*.lib" />
         <file target="native\lib\x86\Debug" src="DirectXMesh\Bin\Desktop_2019\Win32\Debug\*.pdb" />
 
+        <file target="native\lib\x86\Debug" src="DirectXMesh\Bin\Desktop_2019\Win32\DebugSpectre\*.lib" />
+        <file target="native\lib\x86\Debug" src="DirectXMesh\Bin\Desktop_2019\Win32\DebugSpectre\*.pdb" />
+
         <file target="native\lib\x86\Release" src="DirectXMesh\Bin\Desktop_2019\Win32\Release\*.lib" />
         <file target="native\lib\x86\Release" src="DirectXMesh\Bin\Desktop_2019\Win32\Release\*.pdb" />
+
+        <file target="native\lib\x86\Release" src="DirectXMesh\Bin\Desktop_2019\Win32\ReleaseSpectre\*.lib" />
+        <file target="native\lib\x86\Release" src="DirectXMesh\Bin\Desktop_2019\Win32\ReleaseSpectre\*.pdb" />
 
         <file target="native\lib\x64\Debug" src="DirectXMesh\Bin\Desktop_2019\x64\Debug\*.lib" />
         <file target="native\lib\x64\Debug" src="DirectXMesh\Bin\Desktop_2019\x64\Debug\*.pdb" />
 
+        <file target="native\lib\x64\Debug" src="DirectXMesh\Bin\Desktop_2019\x64\DebugSpectre\*.pdb" />
+        <file target="native\lib\x64\Debug" src="DirectXMesh\Bin\Desktop_2019\x64\DebugSpectre\*.pdb" />
+
         <file target="native\lib\x64\Release" src="DirectXMesh\Bin\Desktop_2019\x64\Release\*.lib" />
         <file target="native\lib\x64\Release" src="DirectXMesh\Bin\Desktop_2019\x64\Release\*.pdb" />
+
+        <file target="native\lib\x64\Release" src="DirectXMesh\Bin\Desktop_2019\x64\ReleaseSpectre\*.lib" />
+        <file target="native\lib\x64\Release" src="DirectXMesh\Bin\Desktop_2019\x64\ReleaseSpectre\*.pdb" />
 
         <file src=".nuget/directxmesh_desktop_2019.targets" target="build\native" />
 

--- a/.nuget/directxmesh_desktop_2019.targets
+++ b/.nuget/directxmesh_desktop_2019.targets
@@ -16,12 +16,14 @@
 
   <PropertyGroup>
     <directxmesh-LibPath>$(MSBuildThisFileDirectory)..\..\native\lib\$(PlatformTarget)\$(NuGetConfiguration)</directxmesh-LibPath>
+    <directxmesh-LibName Condition="'$(SpectreMitigation)'!='' AND '$(SpectreMitigation)'!='false'">DirectXMesh_Spectre</directxmesh-LibName>
+    <directxmesh-LibName Condition="'$(directxmesh-LibName)'==''">DirectXMesh</directxmesh-LibName>
   </PropertyGroup>
 
   <ItemDefinitionGroup>
     <Link>
       <AdditionalLibraryDirectories>$(directxmesh-LibPath);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>DirectXMesh.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(directxmesh-LibName).lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 

--- a/.nuget/directxmesh_desktop_win10.nuspec
+++ b/.nuget/directxmesh_desktop_win10.nuspec
@@ -33,20 +33,38 @@ DirectXMesh, a shared source library for performing various geometry content pro
         <file target="native\lib\x86\Debug" src="DirectXMesh\Bin\Desktop_2019_Win10\Win32\Debug\*.lib" />
         <file target="native\lib\x86\Debug" src="DirectXMesh\Bin\Desktop_2019_Win10\Win32\Debug\*.pdb" />
 
+        <file target="native\lib\x86\Debug" src="DirectXMesh\Bin\Desktop_2019_Win10\Win32\DebugSpectre\*.lib" />
+        <file target="native\lib\x86\Debug" src="DirectXMesh\Bin\Desktop_2019_Win10\Win32\DebugSpectre\*.pdb" />
+
         <file target="native\lib\x86\Release" src="DirectXMesh\Bin\Desktop_2019_Win10\Win32\Release\*.lib" />
         <file target="native\lib\x86\Release" src="DirectXMesh\Bin\Desktop_2019_Win10\Win32\Release\*.pdb" />
+
+        <file target="native\lib\x86\Release" src="DirectXMesh\Bin\Desktop_2019_Win10\Win32\ReleaseSpectre\*.lib" />
+        <file target="native\lib\x86\Release" src="DirectXMesh\Bin\Desktop_2019_Win10\Win32\ReleaseSpectre\*.pdb" />
 
         <file target="native\lib\x64\Debug" src="DirectXMesh\Bin\Desktop_2019_Win10\x64\Debug\*.lib" />
         <file target="native\lib\x64\Debug" src="DirectXMesh\Bin\Desktop_2019_Win10\x64\Debug\*.pdb" />
 
+        <file target="native\lib\x64\Debug" src="DirectXMesh\Bin\Desktop_2019_Win10\x64\DebugSpectre\*.lib" />
+        <file target="native\lib\x64\Debug" src="DirectXMesh\Bin\Desktop_2019_Win10\x64\DebugSpectre\*.pdb" />
+
         <file target="native\lib\x64\Release" src="DirectXMesh\Bin\Desktop_2019_Win10\x64\Release\*.lib" />
         <file target="native\lib\x64\Release" src="DirectXMesh\Bin\Desktop_2019_Win10\x64\Release\*.pdb" />
+
+        <file target="native\lib\x64\Release" src="DirectXMesh\Bin\Desktop_2019_Win10\x64\ReleaseSpectre\*.lib" />
+        <file target="native\lib\x64\Release" src="DirectXMesh\Bin\Desktop_2019_Win10\x64\ReleaseSpectre\*.pdb" />
 
         <file target="native\lib\ARM64\Debug" src="DirectXMesh\Bin\Desktop_2019_Win10\ARM64\Debug\*.lib" />
         <file target="native\lib\ARM64\Debug" src="DirectXMesh\Bin\Desktop_2019_Win10\ARM64\Debug\*.pdb" />
 
+        <file target="native\lib\ARM64\Debug" src="DirectXMesh\Bin\Desktop_2019_Win10\ARM64\DebugSpectre\*.lib" />
+        <file target="native\lib\ARM64\Debug" src="DirectXMesh\Bin\Desktop_2019_Win10\ARM64\DebugSpectre\*.pdb" />
+
         <file target="native\lib\ARM64\Release" src="DirectXMesh\Bin\Desktop_2019_Win10\ARM64\Release\*.lib" />
         <file target="native\lib\ARM64\Release" src="DirectXMesh\Bin\Desktop_2019_Win10\ARM64\Release\*.pdb" />
+
+        <file target="native\lib\ARM64\Release" src="DirectXMesh\Bin\Desktop_2019_Win10\ARM64\ReleaseSpectre\*.lib" />
+        <file target="native\lib\ARM64\Release" src="DirectXMesh\Bin\Desktop_2019_Win10\ARM64\ReleaseSpectre\*.pdb" />
 
         <file src=".nuget/directxmesh_desktop_win10.targets" target="build\native" />
 

--- a/.nuget/directxmesh_desktop_win10.targets
+++ b/.nuget/directxmesh_desktop_win10.targets
@@ -16,12 +16,14 @@
 
   <PropertyGroup>
     <directxmesh-LibPath>$(MSBuildThisFileDirectory)..\..\native\lib\$(PlatformTarget)\$(NuGetConfiguration)</directxmesh-LibPath>
+    <directxmesh-LibName Condition="'$(SpectreMitigation)'!='' AND '$(SpectreMitigation)'!='false'">DirectXMesh_Spectre</directxmesh-LibName>
+    <directxmesh-LibName Condition="'$(directxmesh-LibName)'==''">DirectXMesh</directxmesh-LibName>
   </PropertyGroup>
 
   <ItemDefinitionGroup>
     <Link>
       <AdditionalLibraryDirectories>$(directxmesh-LibPath);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>DirectXMesh.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(directxmesh-LibName).lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 

--- a/DirectXMesh/DirectXMesh_Desktop_2019.vcxproj
+++ b/DirectXMesh/DirectXMesh_Desktop_2019.vcxproj
@@ -124,6 +124,11 @@
     <TargetName>DirectXMesh</TargetName>
     <GenerateManifest>true</GenerateManifest>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(SpectreMitigation)'!='' AND '$(SpectreMitigation)'!='false'">
+    <OutDir>Bin\Desktop_2019\$(Platform)\$(Configuration)Spectre\</OutDir>
+    <IntDir>Bin\Desktop_2019\$(Platform)\$(Configuration)Spectre\</IntDir>
+    <TargetName>DirectXMesh_Spectre</TargetName>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <WarningLevel>EnableAllWarnings</WarningLevel>

--- a/DirectXMesh/DirectXMesh_Desktop_2019_Win10.vcxproj
+++ b/DirectXMesh/DirectXMesh_Desktop_2019_Win10.vcxproj
@@ -179,6 +179,11 @@
     <TargetName>DirectXMesh</TargetName>
     <GenerateManifest>true</GenerateManifest>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(SpectreMitigation)'!='' AND '$(SpectreMitigation)'!='false'">
+    <OutDir>Bin\Desktop_2019_Win10\$(Platform)\$(Configuration)Spectre\</OutDir>
+    <IntDir>Bin\Desktop_2019_Win10\$(Platform)\$(Configuration)Spectre\</IntDir>
+    <TargetName>DirectXMesh_Spectre</TargetName>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <WarningLevel>EnableAllWarnings</WarningLevel>

--- a/DirectXMesh/DirectXMesh_Desktop_2022.vcxproj
+++ b/DirectXMesh/DirectXMesh_Desktop_2022.vcxproj
@@ -124,6 +124,11 @@
     <TargetName>DirectXMesh</TargetName>
     <GenerateManifest>true</GenerateManifest>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(SpectreMitigation)'!='' AND '$(SpectreMitigation)'!='false'">
+    <OutDir>Bin\Desktop_2022\$(Platform)\$(Configuration)Spectre\</OutDir>
+    <IntDir>Bin\Desktop_2022\$(Platform)\$(Configuration)Spectre\</IntDir>
+    <TargetName>DirectXMesh_Spectre</TargetName>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <WarningLevel>EnableAllWarnings</WarningLevel>

--- a/DirectXMesh/DirectXMesh_Desktop_2022_Win10.vcxproj
+++ b/DirectXMesh/DirectXMesh_Desktop_2022_Win10.vcxproj
@@ -179,6 +179,11 @@
     <TargetName>DirectXMesh</TargetName>
     <GenerateManifest>true</GenerateManifest>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(SpectreMitigation)'!='' AND '$(SpectreMitigation)'!='false'">
+    <OutDir>Bin\Desktop_2022_Win10\$(Platform)\$(Configuration)Spectre\</OutDir>
+    <IntDir>Bin\Desktop_2022_Win10\$(Platform)\$(Configuration)Spectre\</IntDir>
+    <TargetName>DirectXMesh_Spectre</TargetName>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <WarningLevel>EnableAllWarnings</WarningLevel>


### PR DESCRIPTION
Customers using the BinSkim Microsoft security tool will get flagged when using static C++ libraries not built using ``/Qspectre``. This adds the alternative flavor of the libraries to the **directxmesh_desktop_2019** and **directxmesh_desktop_win10** versions of the NuGet package. The targets automatically selects the Spectre version when building with SpectreMitigations enabled.

> This will double the package size from 9 MB to ~18MB which is reasonable.