### PR TITLE
CMake updated to use /Zc:inline and /Zc:lambda

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,6 +262,12 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
         endforeach()
     endif()
 
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.28)
+        foreach(t IN LISTS TOOL_EXES ITEMS ${PROJECT_NAME})
+          target_compile_options(${t} PRIVATE /Zc:lambda)
+        endforeach()
+    endif()
+
     set(WarningsEXE "/wd4061" "/wd4365" "/wd4514" "/wd4625" "/wd4626" "/wd4627" "/wd4668" "/wd4710" "/wd4751" "/wd4820" "/wd5026" "/wd5027" "/wd5039" "/wd5045" "/wd5219")
     if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.34)
         list(APPEND WarningsEXE "/wd5262" "/wd5264")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,7 +235,7 @@ elseif(MINGW)
     endforeach()
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
     foreach(t IN LISTS TOOL_EXES ITEMS ${PROJECT_NAME})
-      target_compile_options(${t} PRIVATE /sdl /permissive- /JMC- /Zc:__cplusplus)
+      target_compile_options(${t} PRIVATE /sdl /permissive- /JMC- /Zc:__cplusplus /Zc:inline)
     endforeach()
 
     if(ENABLE_CODE_ANALYSIS)


### PR DESCRIPTION
The ``/Zc:inline`` switch enforces C++11 rules on inline visibility which reduces redundant comdats in each OBJ file (i.e. all the DirectXMath inline functions you *didn't* call in that translation unit). This switch is on by default with MSBuild, but is *not* on by default for command-line builds. This update adds this switch to CMake builds as well.

This reduces the size of the Release obj/lib files in half.

There's also a ``/Zc:lambda`` conformance switch for VS 2019 16.8 or later which I'm enabling for coverage.
