### PR TITLE
Test Debug and Release for WSL YAML

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,8 @@ option(BUILD_DX12 "Build with DirectX12 Runtime support" ON)
 # https://devblogs.microsoft.com/cppblog/spectre-mitigations-in-msvc/
 option(ENABLE_SPECTRE_MITIGATION "Build using /Qspectre for MSVC" OFF)
 
+option(DISABLE_MSVC_ITERATOR_DEBUGGING "Disable iterator debugging in Debug configurations with the MSVC CRT" OFF)
+
 option(ENABLE_CODE_ANALYSIS "Use Static Code Analysis on build" OFF)
 
 set(CMAKE_CXX_STANDARD 17)
@@ -295,6 +297,12 @@ if(WIN32)
     foreach(t IN LISTS TOOL_EXES ITEMS ${PROJECT_NAME})
       target_compile_definitions(${t} PRIVATE _UNICODE UNICODE _WIN32_WINNT=${WINVER})
     endforeach()
+
+    if(DISABLE_MSVC_ITERATOR_DEBUGGING)
+      foreach(t IN LISTS TOOL_EXES ITEMS ${PROJECT_NAME})
+        target_compile_definitions(${t} PRIVATE _ITERATOR_DEBUG_LEVEL=0)
+      endforeach()
+    endif()
 endif()
 
 if(BUILD_TOOLS AND WIN32 AND (NOT WINDOWS_STORE))

--- a/build/DirectXMesh-GitHub-WSL-11.yml
+++ b/build/DirectXMesh-GitHub-WSL-11.yml
@@ -90,12 +90,22 @@ jobs:
         }
 
   - task: CMake@1
-    displayName: CMake DirectXMesh
+    displayName: CMake DirectXMesh (Config) dbg
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: -B out -DCMAKE_PREFIX_PATH=$(DEST_DIR)usr/local/share;$(DEST_DIR)usr/local/cmake
+      cmakeArgs: -B out -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=$(DEST_DIR)usr/local/share;$(DEST_DIR)usr/local/cmake
   - task: CMake@1
-    displayName: CMake DirectXMesh (Build)
+    displayName: CMake DirectXMesh (Build) dbg
     inputs:
       cwd: '$(Build.SourcesDirectory)'
       cmakeArgs: --build out -v
+  - task: CMake@1
+    displayName: CMake DirectXMesh (Config) rel
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: -B out2 -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=$(DEST_DIR)usr/local/share;$(DEST_DIR)usr/local/cmake
+  - task: CMake@1
+    displayName: CMake DirectXMesh (Build) rel
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out2 -v

--- a/build/DirectXMesh-GitHub-WSL.yml
+++ b/build/DirectXMesh-GitHub-WSL.yml
@@ -90,12 +90,22 @@ jobs:
         }
 
   - task: CMake@1
-    displayName: CMake DirectXMesh
+    displayName: CMake DirectXMesh (Config) dbg
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: -B out -DCMAKE_PREFIX_PATH=$(DEST_DIR)usr/local/share;$(DEST_DIR)usr/local/cmake
+      cmakeArgs: -B out -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=$(DEST_DIR)usr/local/share;$(DEST_DIR)usr/local/cmake
   - task: CMake@1
-    displayName: CMake DirectXMesh (Build)
+    displayName: CMake DirectXMesh (Build) dbg
     inputs:
       cwd: '$(Build.SourcesDirectory)'
       cmakeArgs: --build out -v
+  - task: CMake@1
+    displayName: CMake DirectXMesh (Config) rel
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: -B out2 -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=$(DEST_DIR)usr/local/share;$(DEST_DIR)usr/local/cmake
+  - task: CMake@1
+    displayName: CMake DirectXMesh (Build) rel
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out2 -v


### PR DESCRIPTION
Update the WSL build pipelines to validate both Debug and Release configurations.

In addition, this PR introduces a new CMake build option ``DISABLE_MSVC_ITERATOR_DEBUGGING`` to allow clients to disable MSVC's iterator debugging in Debug configuration since this is now the 'default' for clang/LLVM for Windows builds even when not using the ``clang-cl`` driver.
