### PR TITLE
CMake code review

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,10 @@ elseif(CMAKE_GENERATOR_PLATFORM MATCHES "^[Aa][Rr][Mm]64$")
     set(DIRECTX_ARCH arm64)
 endif()
 
+if(DEFINED XBOX_CONSOLE_TARGET)
+  set(BUILD_DX12 ON)
+endif()
+
 include(GNUInstallDirs)
 
 #--- Library

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,10 +43,6 @@ elseif(CMAKE_GENERATOR_PLATFORM MATCHES "^[Aa][Rr][Mm]64$")
     set(DIRECTX_ARCH arm64)
 endif()
 
-if(VCPKG_TARGET_IS_XBOX)
-    set(BUILD_DX12 ON)
-endif()
-
 include(GNUInstallDirs)
 
 #--- Library
@@ -88,15 +84,23 @@ if(NOT MINGW)
     target_precompile_headers(${PROJECT_NAME} PRIVATE DirectXMesh/DirectXMeshP.h)
 endif()
 
-if(MINGW OR (NOT WIN32) OR VCPKG_TOOLCHAIN)
+if(MINGW OR (NOT WIN32))
     find_package(directxmath CONFIG REQUIRED)
-    target_link_libraries(${PROJECT_NAME} PUBLIC Microsoft::DirectXMath)
+    find_package(directx-headers CONFIG REQUIRED)
+else()
+    find_package(directxmath CONFIG QUIET)
+    find_package(directx-headers CONFIG QUIET)
+endif()
 
-    if(NOT VCPKG_TARGET_IS_XBOX)
-        find_package(directx-headers CONFIG REQUIRED)
-        target_link_libraries(${PROJECT_NAME} PUBLIC Microsoft::DirectX-Headers)
-        target_compile_definitions(${PROJECT_NAME} PRIVATE USING_DIRECTX_HEADERS)
-    endif()
+if(directxmath_FOUND)
+    message(STATUS "Using DirectXMath package")
+    target_link_libraries(${PROJECT_NAME} PUBLIC Microsoft::DirectXMath)
+endif()
+
+if(directx-headers_FOUND)
+    message(STATUS "Using DirectX-Headers package")
+    target_link_libraries(${PROJECT_NAME} PUBLIC Microsoft::DirectX-Headers)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE USING_DIRECTX_HEADERS)
 endif()
 
 #--- Utilities
@@ -176,7 +180,7 @@ if(BUILD_TOOLS AND WIN32 AND (NOT WINDOWS_STORE))
   target_link_libraries(meshconvert ${PROJECT_NAME} version.lib)
   source_group(meshconvert REGULAR_EXPRESSION meshconvert/*.*)
 
-  if(MINGW OR VCPKG_TOOLCHAIN)
+  if(directxmath_FOUND)
     target_link_libraries(meshconvert Microsoft::DirectXMath)
   endif()
 endif()


### PR DESCRIPTION
Minimize use of VCPKG specific variables, and use standard CMake logic instead.