### PR TITLE
CMake minor cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,10 @@ cmake_minimum_required (VERSION 3.20)
 
 set(DIRECTXMESH_VERSION 1.6.3)
 
+if(DEFINED XBOX_CONSOLE_TARGET)
+  set(CMAKE_TRY_COMPILE_TARGET_TYPE "STATIC_LIBRARY")
+endif()
+
 project(DirectXMesh
   VERSION ${DIRECTXMESH_VERSION}
   DESCRIPTION "DirectXMesh geometry Library"
@@ -130,7 +134,11 @@ if(DEFINED XBOX_CONSOLE_TARGET)
             message(FATAL_ERROR "Microsoft GDK with Xbox Extensions environment needs to be set for Xbox One.")
         endif()
         target_compile_definitions(${PROJECT_NAME} PUBLIC _GAMING_XBOX _GAMING_XBOX_XBOXONE)
+    else()
+        message(FATAL_ERROR "Unknown XBOX_CONSOLE_TARGET")
     endif()
+elseif(WINDOWS_STORE)
+    target_compile_definitions(${PROJECT_NAME} PUBLIC WINAPI_FAMILY=WINAPI_FAMILY_APP)
 endif()
 
 #--- Utilities
@@ -338,10 +346,6 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
 endif()
 
 if(WIN32)
-    if(WINDOWS_STORE)
-      target_compile_definitions(${PROJECT_NAME} PRIVATE WINAPI_FAMILY=WINAPI_FAMILY_APP)
-    endif()
-
     if(BUILD_DX12 OR (${DIRECTX_ARCH} MATCHES "^arm64"))
         message(STATUS "Building with DirectX 12 Runtime support")
         set(WINVER 0x0A00)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,6 +277,9 @@ endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(WarningsLib -Wall -Wpedantic -Wextra)
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 16.0)
+        list(APPEND WarningsLib "-Wno-unsafe-buffer-usage")
+    endif()
     target_compile_options(${PROJECT_NAME} PRIVATE ${WarningsLib})
 
     set(WarningsEXE ${WarningsLib} "-Wno-c++98-compat" "-Wno-c++98-compat-pedantic" "-Wno-switch" "-Wno-switch-enum" "-Wno-double-promotion" "-Wno-exit-time-destructors" "-Wno-missing-prototypes")

--- a/README.md
+++ b/README.md
@@ -86,3 +86,5 @@ The DirectXMesh library is the work of Chuck Walbourn, with contributions from D
 Thanks to Matt Hurliman for his contribution of the meshlet generation functions.
 
 Thanks to Adrian Stone (Game Angst) for the public domain implementation of Tom Forsyth's linear-speed vertex cache optimization, and thanks to Tom Forsyth for his contribution.
+
+Thanks to Andrew Farrier and Scott Matloff for their on-going help with code reviews.


### PR DESCRIPTION
The XBOX_CONSOLE_TARGET variable can be set to ``scarlett`` or ``xboxone`` if built in the appropriate Developer Command Prompt. We don't support ``durango`` for this library anymore.

Also added some warning suppressions for the clang v16 toolset.