### PR TITLE
June 2023 release

### DIFF
--- a/.nuget/directxmesh_desktop_2019.nuspec
+++ b/.nuget/directxmesh_desktop_2019.nuspec
@@ -10,7 +10,7 @@
         <description>This version is for Windows desktop applications using Visual Studio 2019 (16.11) or Visual Studio 2022 and supports Windows 7 / DirectX 11.
 
 DirectXMesh, a shared source library for performing various geometry content processing operations including generating normals and tangent frames, triangle adjacency computations, vertex cache optimization, and meshlet generation.</description>
-        <releaseNotes>Matches the April 28, 2023 release on GitHub.</releaseNotes>
+        <releaseNotes>Matches the June 13, 2023 release on GitHub.</releaseNotes>
         <projectUrl>http://go.microsoft.com/fwlink/?LinkID=324981</projectUrl>
         <repository type="git" url="https://github.com/microsoft/DirectXMesh.git" />
         <icon>images\icon.jpg</icon>

--- a/.nuget/directxmesh_desktop_win10.nuspec
+++ b/.nuget/directxmesh_desktop_win10.nuspec
@@ -10,7 +10,7 @@
         <description>This version is for Windows desktop applications using Visual Studio 2019 (16.11) or Visual Studio 2022 and supports Windows 10 / Windows 11 including both DirectX 11 and DirectX 12.
 
 DirectXMesh, a shared source library for performing various geometry content processing operations including generating normals and tangent frames, triangle adjacency computations, vertex cache optimization, and meshlet generation.</description>
-        <releaseNotes>Matches the April 28, 2023 release on GitHub.</releaseNotes>
+        <releaseNotes>Matches the June 13, 2023 release on GitHub.</releaseNotes>
         <projectUrl>http://go.microsoft.com/fwlink/?LinkID=324981</projectUrl>
         <repository type="git" url="https://github.com/microsoft/DirectXMesh.git" />
         <icon>images\icon.jpg</icon>

--- a/.nuget/directxmesh_uwp.nuspec
+++ b/.nuget/directxmesh_uwp.nuspec
@@ -10,7 +10,7 @@
         <description>This version is for Universal Windows Platform apps on Windows 10 / Windows 11 using Visual Studio 2019 (16.11) or Visual Studio 2022.
 
 DirectXMesh, a shared source library for performing various geometry content processing operations including generating normals and tangent frames, triangle adjacency computations, vertex cache optimization, and meshlet generation.</description>
-        <releaseNotes>Matches the April 28, 2023 release on GitHub.</releaseNotes>
+        <releaseNotes>Matches the June 13, 2023 release on GitHub.</releaseNotes>
         <projectUrl>http://go.microsoft.com/fwlink/?LinkID=324981</projectUrl>
         <repository type="git" url="https://github.com/microsoft/DirectXMesh.git" />
         <icon>images\icon.jpg</icon>

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,11 @@ Releases available for download on [GitHub](https://github.com/microsoft/DirectX
 
 ## Release History
 
+### June 13, 2023
+* CMake project updates
+* meshconvert: Fix minor display issue with error messages
+* meshconvert: Supports Long Paths on Windows 10, Version 1607 or later
+
 ### April 28, 2023
 * CMake project updates and fixes for clang/LLVM v16 warnings
 * meshconvert: Windows on ARM64 version

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ http://go.microsoft.com/fwlink/?LinkID=324981
 
 Copyright (c) Microsoft Corporation.
 
-**April 28, 2023**
+**June 13, 2023**
 
 This package contains DirectXMesh, a shared source library for performing various geometry content processing operations including generating normals and tangent frames, triangle adjacency computations, vertex cache optimization, and meshlet generation.
 


### PR DESCRIPTION
* CMake project updates
* meshconvert: Fix minor display issue with error messages
* meshconvert: Supports Long Paths on Windows 10, Version 1607 or later