### PR TITLE
CMake target file fix

### DIFF
--- a/build/DirectXMesh-config.cmake.in
+++ b/build/DirectXMesh-config.cmake.in
@@ -10,7 +10,7 @@ endif()
 
 include(CMakeFindDependencyMacro)
 
-if(MINGW OR (NOT WIN32) OR VCPKG_TOOLCHAIN)
+if(MINGW OR (NOT WIN32))
     find_dependency(directx-headers CONFIG)
     find_dependency(directxmath CONFIG)
 endif()


### PR DESCRIPTION
The CMakeLists.txt no longer mandates both **directxmath** and **directx-headers** packages be found unless building with MinGW or for Linux. This fixes the behavior for CMake clients consuming this package from VCPKG.