### PR TITLE
CMake targets fixes for optional vs. required packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,12 +215,12 @@ if(BUILD_TOOLS AND WIN32)
     Meshconvert/Mesh.h
     Meshconvert/Mesh.cpp
     Meshconvert/SDKMesh.h)
-  target_include_directories(meshconvert PUBLIC MeshConvert Utilities)
-  target_link_libraries(meshconvert ${PROJECT_NAME} version.lib)
+  target_include_directories(meshconvert PRIVATE MeshConvert Utilities)
+  target_link_libraries(meshconvert PRIVATE ${PROJECT_NAME} version.lib)
   source_group(meshconvert REGULAR_EXPRESSION meshconvert/*.*)
 
   if(directxmath_FOUND)
-    target_link_libraries(meshconvert Microsoft::DirectXMath)
+    target_link_libraries(meshconvert PRIVATE Microsoft::DirectXMath)
   endif()
 endif()
 

--- a/build/DirectXMesh-config.cmake.in
+++ b/build/DirectXMesh-config.cmake.in
@@ -11,8 +11,11 @@ endif()
 include(CMakeFindDependencyMacro)
 
 if(MINGW OR (NOT WIN32))
-    find_dependency(directx-headers CONFIG)
-    find_dependency(directxmath CONFIG)
+    find_dependency(directx-headers)
+    find_dependency(directxmath)
+else()
+    find_package(directx-headers CONFIG QUIET)
+    find_package(directxmath CONFIG QUIET)
 endif()
 
 check_required_components("@PROJECT_NAME@")


### PR DESCRIPTION
WIth the changes to make use of DirectXMath & DirectX-Headers 'optional' for VCPKG scenarios unless using MinGW -or- Linux, the generated targets file needed more robust handling of these targets.

Also made sure that explicit 'scope' is used consistently with all CMake ``target_`` commands.