### PR TITLE
Suppress some additional clang v16 warnings when upgrading to clangcl

### DIFF
--- a/DirectXMesh/DirectXMeshP.h
+++ b/DirectXMesh/DirectXMeshP.h
@@ -58,6 +58,8 @@
 #pragma clang diagnostic ignored "-Wfloat-equal"
 #pragma clang diagnostic ignored "-Wreserved-id-macro"
 #pragma clang diagnostic ignored "-Wundef"
+#pragma clang diagnostic ignored "-Wunknown-warning-option"
+#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
 #endif
 
 #ifdef _WIN32


### PR DESCRIPTION
The CMake scenario already disables the new clang v16 warning, but if you upgrade the VCXPROJ project to clangcl, it reappears.