### PR TITLE
AArch32 (ARM32) architecture deprecation

### DIFF
--- a/.nuget/directxmesh_uwp.nuspec
+++ b/.nuget/directxmesh_uwp.nuspec
@@ -30,12 +30,6 @@ DirectXMesh, a shared source library for performing various geometry content pro
 
         <file target="include" src="Utilities\*.h" />
 
-        <file target="native\lib\ARM\Debug" src="DirectXMesh\Bin\Windows10_2019\ARM\Debug\*.lib" />
-        <file target="native\lib\ARM\Debug" src="DirectXMesh\Bin\Windows10_2019\ARM\Debug\*.pdb" />
-
-        <file target="native\lib\ARM\Release" src="DirectXMesh\Bin\Windows10_2019\ARM\Release\*.lib" />
-        <file target="native\lib\ARM\Release" src="DirectXMesh\Bin\Windows10_2019\ARM\Release\*.pdb" />
-
         <file target="native\lib\ARM64\Debug" src="DirectXMesh\Bin\Windows10_2019\ARM64\Debug\*.lib" />
         <file target="native\lib\ARM64\Debug" src="DirectXMesh\Bin\Windows10_2019\ARM64\Debug\*.pdb" />
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -30,15 +30,6 @@
       "hidden": true
     },
     {
-      "name": "ARM",
-      "architecture": {
-        "value": "arm",
-        "strategy": "external"
-      },
-      "cacheVariables": { "DIRECTX_ARCH": "arm" },
-      "hidden": true
-    },
-    {
       "name": "ARM64",
       "architecture": {
         "value": "arm64",
@@ -173,8 +164,6 @@
     { "name": "x64-Release-UWP"  , "description": "MSVC for x64 (Release) for UWP", "inherits": [ "base", "x64", "Release", "MSVC", "UWP" ] },
     { "name": "x86-Debug-UWP"    , "description": "MSVC for x86 (Debug) for UWP", "inherits": [ "base", "x86", "Debug", "MSVC", "UWP" ] },
     { "name": "x86-Release-UWP"  , "description": "MSVC for x86 (Release) for UWP", "inherits": [ "base", "x86", "Release", "MSVC", "UWP" ] },
-    { "name": "arm-Debug-UWP"    , "description": "MSVC for ARM (Debug) for UWP", "inherits": [ "base", "ARM", "Debug", "MSVC", "UWP" ] },
-    { "name": "arm-Release-UWP"  , "description": "MSVC for ARM (Release) for UWP", "inherits": [ "base", "ARM", "Release", "MSVC", "UWP" ] },
     { "name": "arm64-Debug-UWP"  , "description": "MSVC for ARM64 (Debug) for UWP", "inherits": [ "base", "ARM64", "Debug", "MSVC", "UWP" ] },
     { "name": "arm64-Release-UWP", "description": "MSVC for ARM64 (Release) for UWP", "inherits": [ "base", "ARM64", "Release", "MSVC", "UWP" ] },
 

--- a/DirectXMesh/DirectXMesh_Windows10_2019.vcxproj
+++ b/DirectXMesh/DirectXMesh_Windows10_2019.vcxproj
@@ -1,10 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
-    <ProjectConfiguration Include="Debug|ARM">
-      <Configuration>Debug</Configuration>
-      <Platform>ARM</Platform>
-    </ProjectConfiguration>
     <ProjectConfiguration Include="Debug|ARM64">
       <Configuration>Debug</Configuration>
       <Platform>ARM64</Platform>
@@ -16,10 +12,6 @@
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|ARM">
-      <Configuration>Release</Configuration>
-      <Platform>ARM</Platform>
     </ProjectConfiguration>
     <ProjectConfiguration Include="Release|ARM64">
       <Configuration>Release</Configuration>
@@ -49,9 +41,7 @@
     <ClCompile Include="DirectXMeshUtil.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
@@ -89,11 +79,6 @@
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
@@ -105,11 +90,6 @@
     <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>
@@ -135,13 +115,7 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="PropertySheets">
@@ -167,19 +141,7 @@
     <TargetName>DirectXMesh</TargetName>
     <GenerateManifest>false</GenerateManifest>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
-    <TargetName>DirectXMesh</TargetName>
-    <GenerateManifest>false</GenerateManifest>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
-    <TargetName>DirectXMesh</TargetName>
-    <GenerateManifest>false</GenerateManifest>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
     <TargetName>DirectXMesh</TargetName>
@@ -249,29 +211,6 @@
       <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
-    <ClCompile>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <ForcedUsingFiles />
-      <CompileAsWinRT>false</CompileAsWinRT>
-      <SDLCheck>true</SDLCheck>
-      <FloatingPointModel>Fast</FloatingPointModel>
-      <ProgramDataBaseFileName>$(IntDir)$(TargetName).pdb</ProgramDataBaseFileName>
-      <WarningLevel>EnableAllWarnings</WarningLevel>
-      <PrecompiledHeaderFile>DirectXMeshP.h</PrecompiledHeaderFile>
-      <PreprocessorDefinitions>_CRT_STDIO_ARBITRARY_WIDE_SPECIFIERS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
-      <AdditionalOptions>/Zc:__cplusplus /ZH:SHA_256 %(AdditionalOptions)</AdditionalOptions>
-      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <SupportJustMyCode>false</SupportJustMyCode>
-      <ExternalWarningLevel>Level4</ExternalWarningLevel>
-    </ClCompile>
-    <Link>
-      <SubSystem>Console</SubSystem>
-      <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
-      <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
-    </Link>
-  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
@@ -288,27 +227,6 @@
       <AdditionalOptions>/Zc:__cplusplus /ZH:SHA_256 %(AdditionalOptions)</AdditionalOptions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <SupportJustMyCode>false</SupportJustMyCode>
-      <ExternalWarningLevel>Level4</ExternalWarningLevel>
-    </ClCompile>
-    <Link>
-      <SubSystem>Console</SubSystem>
-      <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
-      <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
-    <ClCompile>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <ForcedUsingFiles />
-      <CompileAsWinRT>false</CompileAsWinRT>
-      <SDLCheck>true</SDLCheck>
-      <FloatingPointModel>Fast</FloatingPointModel>
-      <ProgramDataBaseFileName>$(IntDir)$(TargetName).pdb</ProgramDataBaseFileName>
-      <WarningLevel>EnableAllWarnings</WarningLevel>
-      <PrecompiledHeaderFile>DirectXMeshP.h</PrecompiledHeaderFile>
-      <PreprocessorDefinitions>_CRT_STDIO_ARBITRARY_WIDE_SPECIFIERS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
-      <AdditionalOptions>/Zc:__cplusplus /ZH:SHA_256 %(AdditionalOptions)</AdditionalOptions>
       <ExternalWarningLevel>Level4</ExternalWarningLevel>
     </ClCompile>
     <Link>

--- a/DirectXMesh/DirectXMesh_Windows10_2022.vcxproj
+++ b/DirectXMesh/DirectXMesh_Windows10_2022.vcxproj
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
-    <ProjectConfiguration Include="Debug|ARM">
-      <Configuration>Debug</Configuration>
-      <Platform>ARM</Platform>
-    </ProjectConfiguration>
     <ProjectConfiguration Include="Debug|ARM64">
       <Configuration>Debug</Configuration>
       <Platform>ARM64</Platform>
@@ -16,10 +12,6 @@
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|ARM">
-      <Configuration>Release</Configuration>
-      <Platform>ARM</Platform>
     </ProjectConfiguration>
     <ProjectConfiguration Include="Release|ARM64">
       <Configuration>Release</Configuration>
@@ -49,9 +41,7 @@
     <ClCompile Include="DirectXMeshUtil.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
@@ -89,11 +79,6 @@
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
@@ -105,11 +90,6 @@
     <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
@@ -135,13 +115,7 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="PropertySheets">
@@ -167,19 +141,7 @@
     <TargetName>DirectXMesh</TargetName>
     <GenerateManifest>false</GenerateManifest>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
-    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
-    <TargetName>DirectXMesh</TargetName>
-    <GenerateManifest>false</GenerateManifest>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
-    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
-    <TargetName>DirectXMesh</TargetName>
-    <GenerateManifest>false</GenerateManifest>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
     <TargetName>DirectXMesh</TargetName>
@@ -249,29 +211,6 @@
       <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
-    <ClCompile>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <ForcedUsingFiles />
-      <CompileAsWinRT>false</CompileAsWinRT>
-      <SDLCheck>true</SDLCheck>
-      <FloatingPointModel>Fast</FloatingPointModel>
-      <ProgramDataBaseFileName>$(IntDir)$(TargetName).pdb</ProgramDataBaseFileName>
-      <WarningLevel>EnableAllWarnings</WarningLevel>
-      <PrecompiledHeaderFile>DirectXMeshP.h</PrecompiledHeaderFile>
-      <PreprocessorDefinitions>_CRT_STDIO_ARBITRARY_WIDE_SPECIFIERS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
-      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
-      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <SupportJustMyCode>false</SupportJustMyCode>
-      <ExternalWarningLevel>Level4</ExternalWarningLevel>
-    </ClCompile>
-    <Link>
-      <SubSystem>Console</SubSystem>
-      <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
-      <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
-    </Link>
-  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
@@ -288,27 +227,6 @@
       <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <SupportJustMyCode>false</SupportJustMyCode>
-      <ExternalWarningLevel>Level4</ExternalWarningLevel>
-    </ClCompile>
-    <Link>
-      <SubSystem>Console</SubSystem>
-      <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
-      <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
-    <ClCompile>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <ForcedUsingFiles />
-      <CompileAsWinRT>false</CompileAsWinRT>
-      <SDLCheck>true</SDLCheck>
-      <FloatingPointModel>Fast</FloatingPointModel>
-      <ProgramDataBaseFileName>$(IntDir)$(TargetName).pdb</ProgramDataBaseFileName>
-      <WarningLevel>EnableAllWarnings</WarningLevel>
-      <PrecompiledHeaderFile>DirectXMeshP.h</PrecompiledHeaderFile>
-      <PreprocessorDefinitions>_CRT_STDIO_ARBITRARY_WIDE_SPECIFIERS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
-      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
       <ExternalWarningLevel>Level4</ExternalWarningLevel>
     </ClCompile>
     <Link>

--- a/DirectXMesh_Windows10_2019.sln
+++ b/DirectXMesh_Windows10_2019.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27703.2000
+# Visual Studio Version 17
+VisualStudioVersion = 17.7.34009.444
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "DirectXMesh", "DirectXMesh\DirectXMesh_Windows10_2019.vcxproj", "{107A408E-C148-4594-B469-075FE0ADB7A5}"
 EndProject
@@ -12,26 +12,20 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|ARM = Debug|ARM
 		Debug|ARM64 = Debug|ARM64
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
-		Release|ARM = Release|ARM
 		Release|ARM64 = Release|ARM64
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{107A408E-C148-4594-B469-075FE0ADB7A5}.Debug|ARM.ActiveCfg = Debug|ARM
-		{107A408E-C148-4594-B469-075FE0ADB7A5}.Debug|ARM.Build.0 = Debug|ARM
 		{107A408E-C148-4594-B469-075FE0ADB7A5}.Debug|ARM64.ActiveCfg = Debug|ARM64
 		{107A408E-C148-4594-B469-075FE0ADB7A5}.Debug|ARM64.Build.0 = Debug|ARM64
 		{107A408E-C148-4594-B469-075FE0ADB7A5}.Debug|x64.ActiveCfg = Debug|x64
 		{107A408E-C148-4594-B469-075FE0ADB7A5}.Debug|x64.Build.0 = Debug|x64
 		{107A408E-C148-4594-B469-075FE0ADB7A5}.Debug|x86.ActiveCfg = Debug|Win32
 		{107A408E-C148-4594-B469-075FE0ADB7A5}.Debug|x86.Build.0 = Debug|Win32
-		{107A408E-C148-4594-B469-075FE0ADB7A5}.Release|ARM.ActiveCfg = Release|ARM
-		{107A408E-C148-4594-B469-075FE0ADB7A5}.Release|ARM.Build.0 = Release|ARM
 		{107A408E-C148-4594-B469-075FE0ADB7A5}.Release|ARM64.ActiveCfg = Release|ARM64
 		{107A408E-C148-4594-B469-075FE0ADB7A5}.Release|ARM64.Build.0 = Release|ARM64
 		{107A408E-C148-4594-B469-075FE0ADB7A5}.Release|x64.ActiveCfg = Release|x64

--- a/DirectXMesh_Windows10_2019.sln
+++ b/DirectXMesh_Windows10_2019.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.7.34009.444
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.33927.289
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "DirectXMesh", "DirectXMesh\DirectXMesh_Windows10_2019.vcxproj", "{107A408E-C148-4594-B469-075FE0ADB7A5}"
 EndProject

--- a/DirectXMesh_Windows10_2022.sln
+++ b/DirectXMesh_Windows10_2022.sln
@@ -1,7 +1,6 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
-VisualStudioVersion = 15.0.27703.2000
+VisualStudioVersion = 17.7.34009.444
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "DirectXMesh", "DirectXMesh\DirectXMesh_Windows10_2022.vcxproj", "{107A408E-C148-4594-B469-075FE0ADB7A5}"
 EndProject
@@ -12,26 +11,20 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|ARM = Debug|ARM
 		Debug|ARM64 = Debug|ARM64
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
-		Release|ARM = Release|ARM
 		Release|ARM64 = Release|ARM64
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{107A408E-C148-4594-B469-075FE0ADB7A5}.Debug|ARM.ActiveCfg = Debug|ARM
-		{107A408E-C148-4594-B469-075FE0ADB7A5}.Debug|ARM.Build.0 = Debug|ARM
 		{107A408E-C148-4594-B469-075FE0ADB7A5}.Debug|ARM64.ActiveCfg = Debug|ARM64
 		{107A408E-C148-4594-B469-075FE0ADB7A5}.Debug|ARM64.Build.0 = Debug|ARM64
 		{107A408E-C148-4594-B469-075FE0ADB7A5}.Debug|x64.ActiveCfg = Debug|x64
 		{107A408E-C148-4594-B469-075FE0ADB7A5}.Debug|x64.Build.0 = Debug|x64
 		{107A408E-C148-4594-B469-075FE0ADB7A5}.Debug|x86.ActiveCfg = Debug|Win32
 		{107A408E-C148-4594-B469-075FE0ADB7A5}.Debug|x86.Build.0 = Debug|Win32
-		{107A408E-C148-4594-B469-075FE0ADB7A5}.Release|ARM.ActiveCfg = Release|ARM
-		{107A408E-C148-4594-B469-075FE0ADB7A5}.Release|ARM.Build.0 = Release|ARM
 		{107A408E-C148-4594-B469-075FE0ADB7A5}.Release|ARM64.ActiveCfg = Release|ARM64
 		{107A408E-C148-4594-B469-075FE0ADB7A5}.Release|ARM64.Build.0 = Release|ARM64
 		{107A408E-C148-4594-B469-075FE0ADB7A5}.Release|x64.ActiveCfg = Release|x64

--- a/build/DirectXMesh-GitHub-CMake-Dev17.yml
+++ b/build/DirectXMesh-GitHub-CMake-Dev17.yml
@@ -94,16 +94,6 @@ jobs:
       cwd: '$(Build.SourcesDirectory)'
       cmakeArgs: --build out4 -v
   - task: CMake@1
-    displayName: 'CMake (UWP): Config ARM'
-    inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A ARM -B out5 -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0'
-  - task: CMake@1
-    displayName: 'CMake (UWP): Build ARM'
-    inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out5 -v
-  - task: CMake@1
     displayName: 'CMake (ClangCl): Config x64'
     inputs:
       cwd: '$(Build.SourcesDirectory)'

--- a/build/DirectXMesh-GitHub-CMake.yml
+++ b/build/DirectXMesh-GitHub-CMake.yml
@@ -106,16 +106,6 @@ jobs:
       cwd: '$(Build.SourcesDirectory)'
       cmakeArgs: --build out4 -v
   - task: CMake@1
-    displayName: 'CMake (UWP): Config ARM'
-    inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A ARM -B out5 -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0'
-  - task: CMake@1
-    displayName: 'CMake (UWP): Build ARM'
-    inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out5 -v
-  - task: CMake@1
     displayName: 'CMake (ClangCl): Config x64'
     inputs:
       cwd: '$(Build.SourcesDirectory)'

--- a/build/DirectXMesh-GitHub-Dev17.yml
+++ b/build/DirectXMesh-GitHub-Dev17.yml
@@ -246,22 +246,6 @@ jobs:
       configuration: Release
       msbuildArchitecture: x64
   - task: VSBuild@1
-    displayName: Build solution DirectXMesh_Windows10_2022.sln armdbg
-    inputs:
-      solution: DirectXMesh_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM
-      configuration: Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution DirectXMesh_Windows10_2022.sln armrel
-    inputs:
-      solution: DirectXMesh_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM
-      configuration: Release
-      msbuildArchitecture: x64
-  - task: VSBuild@1
     displayName: Build solution DirectXMesh_Windows10_2022.sln arm64dbg
     inputs:
       solution: DirectXMesh_Windows10_2022.sln

--- a/build/DirectXMesh-GitHub-SDK-prerelease.yml
+++ b/build/DirectXMesh-GitHub-SDK-prerelease.yml
@@ -193,11 +193,6 @@ jobs:
       command: custom
       arguments: install -prerelease Microsoft.Windows.SDK.CPP.x86 -ExcludeVersion -OutputDirectory $(EXTRACTED_FOLDER)\SDK
   - task: NuGetCommand@2
-    displayName: NuGet Install WSDK arm
-    inputs:
-      command: custom
-      arguments: install -prerelease Microsoft.Windows.SDK.CPP.arm -ExcludeVersion -OutputDirectory $(EXTRACTED_FOLDER)\SDK
-  - task: NuGetCommand@2
     displayName: NuGet Install WSDK arm64
     inputs:
       command: custom
@@ -235,20 +230,6 @@ jobs:
       solution: DirectXMesh_Windows10_2019.sln
       msbuildArgs: /p:PreferredToolArchitecture=x64
       platform: x64
-      configuration: Release
-  - task: VSBuild@1
-    displayName: Build solution DirectXMesh_Windows10_2019.sln armdbg
-    inputs:
-      solution: DirectXMesh_Windows10_2019.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXMesh_Windows10_2019.sln armrel
-    inputs:
-      solution: DirectXMesh_Windows10_2019.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM
       configuration: Release
   - task: VSBuild@1
     displayName: Build solution DirectXMesh_Windows10_2019.sln arm64dbg

--- a/build/DirectXMesh-GitHub-SDK-release.yml
+++ b/build/DirectXMesh-GitHub-SDK-release.yml
@@ -193,11 +193,6 @@ jobs:
       command: custom
       arguments: install Microsoft.Windows.SDK.CPP.x86 -ExcludeVersion -OutputDirectory $(EXTRACTED_FOLDER)\SDK
   - task: NuGetCommand@2
-    displayName: NuGet Install WSDK arm
-    inputs:
-      command: custom
-      arguments: install Microsoft.Windows.SDK.CPP.arm -ExcludeVersion -OutputDirectory $(EXTRACTED_FOLDER)\SDK
-  - task: NuGetCommand@2
     displayName: NuGet Install WSDK arm64
     inputs:
       command: custom
@@ -235,20 +230,6 @@ jobs:
       solution: DirectXMesh_Windows10_2019.sln
       msbuildArgs: /p:PreferredToolArchitecture=x64
       platform: x64
-      configuration: Release
-  - task: VSBuild@1
-    displayName: Build solution DirectXMesh_Windows10_2019.sln armdbg
-    inputs:
-      solution: DirectXMesh_Windows10_2019.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXMesh_Windows10_2019.sln armrel
-    inputs:
-      solution: DirectXMesh_Windows10_2019.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM
       configuration: Release
   - task: VSBuild@1
     displayName: Build solution DirectXMesh_Windows10_2019.sln arm64dbg

--- a/build/DirectXMesh-GitHub.yml
+++ b/build/DirectXMesh-GitHub.yml
@@ -244,20 +244,6 @@ jobs:
       platform: x64
       configuration: Release
   - task: VSBuild@1
-    displayName: Build solution DirectXMesh_Windows10_2019.sln armdbg
-    inputs:
-      solution: DirectXMesh_Windows10_2019.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXMesh_Windows10_2019.sln armrel
-    inputs:
-      solution: DirectXMesh_Windows10_2019.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM
-      configuration: Release
-  - task: VSBuild@1
     displayName: Build solution DirectXMesh_Windows10_2019.sln arm64dbg
     inputs:
       solution: DirectXMesh_Windows10_2019.sln

--- a/build/Directory.Build.props
+++ b/build/Directory.Build.props
@@ -23,9 +23,6 @@
   <Import Condition="'$(WSDKEnableBWOI)' == 'true' and '$(Platform)' == 'Win32'"
           Project="$(ExtractedFolder)SDK\Microsoft.Windows.SDK.cpp.x86\build\native\Microsoft.Windows.SDK.cpp.x86.props" />
 
-  <Import Condition="'$(WSDKEnableBWOI)' == 'true' and '$(Platform)' == 'ARM'"
-          Project="$(ExtractedFolder)SDK\Microsoft.Windows.SDK.cpp.arm\build\native\Microsoft.Windows.SDK.cpp.arm.props" />
-
   <Import Condition="'$(WSDKEnableBWOI)' == 'true' and '$(Platform)' == 'ARM64'"
           Project="$(ExtractedFolder)SDK\Microsoft.Windows.SDK.cpp.arm64\build\native\Microsoft.Windows.SDK.cpp.arm64.props" />
 


### PR DESCRIPTION
32-bit ARM support is being deprecated for the UWP platform, and support is being removed from newer ARM-based CPUs and the Windows 11 OS.

> 32-bit ARM was never officially supported for Win32 desktop development.

See [Microsoft Learn](https://learn.microsoft.com/windows/arm/arm32-to-arm64)