### PR TITLE
Optionally create shared library for both Windows and Linux.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 cmake_minimum_required (VERSION 3.20)
 
-set(DIRECTXMESH_VERSION 1.6.5)
+set(DIRECTXMESH_VERSION 1.6.4)
 
 if(WINDOWS_STORE OR (DEFINED XBOX_CONSOLE_TARGET))
   set(CMAKE_TRY_COMPILE_TARGET_TYPE "STATIC_LIBRARY")
@@ -80,17 +80,41 @@ set(LIBRARY_SOURCES
     DirectXMesh/DirectXMeshWeldVertices.cpp)
 
 add_library(${PROJECT_NAME} STATIC ${LIBRARY_SOURCES} ${LIBRARY_HEADERS})
+if(BUILD_SHARED_LIBS)
+  if(WIN32)
+    string(REPLACE "." "," _RC_VER "${PROJECT_VERSION}.0")
+    configure_file(
+      "${CMAKE_CURRENT_SOURCE_DIR}/build/DirectXMesh.rc.in"
+      "${CMAKE_CURRENT_BINARY_DIR}/DirectXMesh.rc" @ONLY)
+    add_library(${PROJECT_NAME}_shared SHARED ${LIBRARY_SOURCES} ${LIBRARY_HEADERS} "${CMAKE_CURRENT_BINARY_DIR}/DirectXMesh.rc")
+  else()
+    add_library(${PROJECT_NAME}_shared SHARED ${LIBRARY_SOURCES} ${LIBRARY_HEADERS})
+  endif()
+
+  set_target_properties(${PROJECT_NAME}_shared PROPERTIES OUTPUT_NAME ${PROJECT_NAME})
+endif()
 
 source_group(${PROJECT_NAME} REGULAR_EXPRESSION DirectXMesh/*.*)
+if(BUILD_SHARED_LIBS)
+  source_group(${PROJECT_NAME}_shared REGULAR_EXPRESSION DirectXMesh/*.*)
+endif()
 
 target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/DirectXMesh>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+if(BUILD_SHARED_LIBS)
+  target_include_directories(${PROJECT_NAME}_shared PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/DirectXMesh>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+endif()
 
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_11)
 
 if(NOT MINGW)
     target_precompile_headers(${PROJECT_NAME} PRIVATE DirectXMesh/DirectXMeshP.h)
+    if(BUILD_SHARED_LIBS)
+      target_precompile_headers(${PROJECT_NAME}_shared PRIVATE DirectXMesh/DirectXMeshP.h)
+    endif()
 endif()
 
 if(MINGW OR (NOT WIN32))
@@ -104,12 +128,19 @@ endif()
 if(directxmath_FOUND)
     message(STATUS "Using DirectXMath package")
     target_link_libraries(${PROJECT_NAME} PUBLIC Microsoft::DirectXMath)
+    if(BUILD_SHARED_LIBS)
+      target_link_libraries(${PROJECT_NAME}_shared PUBLIC Microsoft::DirectXMath)
+    endif()
 endif()
 
 if(directx-headers_FOUND)
     message(STATUS "Using DirectX-Headers package")
     target_link_libraries(${PROJECT_NAME} PUBLIC Microsoft::DirectX-Headers)
     target_compile_definitions(${PROJECT_NAME} PUBLIC USING_DIRECTX_HEADERS)
+    if(BUILD_SHARED_LIBS)
+      target_link_libraries(${PROJECT_NAME}_shared PUBLIC Microsoft::DirectX-Headers)
+      target_compile_definitions(${PROJECT_NAME}_shared PUBLIC USING_DIRECTX_HEADERS)
+    endif()
 endif()
 
 include(CheckIncludeFileCXX)
@@ -139,6 +170,9 @@ if(DEFINED XBOX_CONSOLE_TARGET)
     endif()
 elseif(WINDOWS_STORE)
     target_compile_definitions(${PROJECT_NAME} PUBLIC WINAPI_FAMILY=WINAPI_FAMILY_APP)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(${PROJECT_NAME}_shared PUBLIC WINAPI_FAMILY=WINAPI_FAMILY_APP)
+    endif()
 endif()
 
 #--- Utilities
@@ -170,6 +204,13 @@ install(TARGETS ${PROJECT_NAME}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
   COMPONENT library)
+if(BUILD_SHARED_LIBS)
+  install(TARGETS ${PROJECT_NAME}_shared
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    COMPONENT library)
+endif()
 
 # Create pkg-config file
 include(build/JoinPaths.cmake)

--- a/DirectXMesh/scoped.h
+++ b/DirectXMesh/scoped.h
@@ -61,7 +61,14 @@ inline ScopedAlignedArrayFloat make_AlignedArrayFloat(uint64_t count)
     return ScopedAlignedArrayFloat(static_cast<float*>(ptr));
 }
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wignored-attributes"
+#endif
 using ScopedAlignedArrayXMVECTOR = std::unique_ptr<DirectX::XMVECTOR[], aligned_deleter>;
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
 inline ScopedAlignedArrayXMVECTOR make_AlignedArrayXMVECTOR(uint64_t count)
 {

--- a/build/DirectxMesh.rc.in
+++ b/build/DirectxMesh.rc.in
@@ -1,0 +1,107 @@
+// Microsoft Visual C++ generated resource script.
+//
+
+#define APSTUDIO_READONLY_SYMBOLS
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 2 resource.
+//
+#define IDC_STATIC -1
+#include <winresrc.h>
+
+
+
+/////////////////////////////////////////////////////////////////////////////
+#undef APSTUDIO_READONLY_SYMBOLS
+
+/////////////////////////////////////////////////////////////////////////////
+// English (United States) resources
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
+LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
+#pragma code_page(1252)
+
+
+
+#ifdef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// TEXTINCLUDE
+//
+
+1 TEXTINCLUDE 
+BEGIN
+    "resource.h\0"
+END
+
+2 TEXTINCLUDE 
+BEGIN
+    "#define IDC_STATIC -1\r\n"
+    "#include <winresrc.h>\r\n"
+    "\r\n"
+    "\r\n"
+    "\0"
+END
+
+3 TEXTINCLUDE 
+BEGIN
+    "\r\n"
+    "\0"
+END
+
+#endif    // APSTUDIO_INVOKED
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Version
+//
+
+VS_VERSION_INFO VERSIONINFO
+ FILEVERSION @_RC_VER@
+ PRODUCTVERSION @_RC_VER@
+ FILEFLAGSMASK 0x3fL
+#ifdef _DEBUG
+ FILEFLAGS 0x1L
+#else
+ FILEFLAGS 0x0L
+#endif
+ FILEOS 0x40004L
+ FILETYPE 0x1L
+ FILESUBTYPE 0x0L
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904b0"
+        BEGIN
+            VALUE "CompanyName", "Microsoft Corp"
+            VALUE "FileDescription", "@PROJECT_DESCRIPTION@"
+            VALUE "FileVersion", "@PROJECT_VERSION@.0"
+            VALUE "InternalName", "@CMAKE_SHARED_LIBRARY_PREFIX@@PROJECT_NAME@@CMAKE_SHARED_LIBRARY_SUFFIX@"
+            VALUE "LegalCopyright", "Copyright (c) Microsoft Corp."
+            VALUE "OriginalFilename", "@CMAKE_SHARED_LIBRARY_PREFIX@@PROJECT_NAME@@CMAKE_SHARED_LIBRARY_SUFFIX@"
+            VALUE "ProductName", "@PROJECT_NAME@"
+            VALUE "ProductVersion", "@PROJECT_VERSION@.0"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1200
+    END
+END
+
+#endif    // English (United States) resources
+/////////////////////////////////////////////////////////////////////////////
+
+
+
+#ifndef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 3 resource.
+//
+
+
+/////////////////////////////////////////////////////////////////////////////
+#endif    // not APSTUDIO_INVOKED
+


### PR DESCRIPTION
Also suppress warning that appears only when building shared libraries.