### PR TITLE
Use fixed width integers for underlying enum types

### DIFF
--- a/DirectXMesh/DirectXMesh.h
+++ b/DirectXMesh/DirectXMesh.h
@@ -244,7 +244,7 @@ namespace DirectX
     //---------------------------------------------------------------------------------
     // Normals, Tangents, and Bi-Tangents Computation
 
-    enum CNORM_FLAGS : unsigned long
+    enum CNORM_FLAGS : uint32_t
     {
         CNORM_DEFAULT = 0x0,
         // Default is to compute normals using weight-by-angle
@@ -316,7 +316,7 @@ namespace DirectX
     //---------------------------------------------------------------------------------
     // Mesh clean-up and validation
 
-    enum VALIDATE_FLAGS : unsigned long
+    enum VALIDATE_FLAGS : uint32_t
     {
         VALIDATE_DEFAULT = 0x0,
 
@@ -549,7 +549,7 @@ namespace DirectX
     constexpr size_t MESHLET_MINIMUM_SIZE = 32u;
     constexpr size_t MESHLET_MAXIMUM_SIZE = 256u;
 
-    enum MESHLET_FLAGS : unsigned long
+    enum MESHLET_FLAGS : uint32_t
     {
         MESHLET_DEFAULT = 0x0,
 

--- a/DirectXMesh/DirectXMesh.inl
+++ b/DirectXMesh/DirectXMesh.inl
@@ -14,9 +14,9 @@
 //=====================================================================================
 // Bitmask flags enumerator operators
 //=====================================================================================
-DEFINE_ENUM_FLAG_OPERATORS(CNORM_FLAGS);
-DEFINE_ENUM_FLAG_OPERATORS(VALIDATE_FLAGS);
-DEFINE_ENUM_FLAG_OPERATORS(MESHLET_FLAGS);
+DEFINE_ENUM_FLAG_OPERATORS(CNORM_FLAGS)
+DEFINE_ENUM_FLAG_OPERATORS(VALIDATE_FLAGS)
+DEFINE_ENUM_FLAG_OPERATORS(MESHLET_FLAGS)
 
 
 //=====================================================================================

--- a/Meshconvert/Meshconvert.cpp
+++ b/Meshconvert/Meshconvert.cpp
@@ -673,7 +673,7 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
             hr = inMesh->ComputeNormals(flags);
             if (FAILED(hr))
             {
-                wprintf(L"\nERROR: Failed computing normals (flags:%lX, %08X%ls)\n",
+                wprintf(L"\nERROR: Failed computing normals (flags:%X, %08X%ls)\n",
                     flags, static_cast<unsigned int>(hr), GetErrorDesc(hr));
                 return 1;
             }


### PR DESCRIPTION
Originally I used `DWORD` for flags. When I removed Windows-specific types, I changed it to `unsigned long` to keep the signature the same. The ask is to use `uint32_t` instead which is more consistent on Windows vs. Linux.

Also removed 'extra-semi' for macro.