### PR TITLE
Fix for CMake on WSL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,11 @@ endif()
 
 if(MINGW OR (NOT WIN32))
     find_package(directxmath CONFIG REQUIRED)
+    target_link_libraries(${PROJECT_NAME} PUBLIC Microsoft::DirectXMath)
+
     find_package(directx-headers CONFIG REQUIRED)
+    target_link_libraries(${PROJECT_NAME} PUBLIC Microsoft::DirectX-Headers)
+    target_compile_definitions(${PROJECT_NAME} PUBLIC USING_DIRECTX_HEADERS)
 else()
     find_package(directxmath CONFIG QUIET)
     find_package(directx-headers CONFIG QUIET)


### PR DESCRIPTION
For Win32 scenarios, DirectXMath and DirectX-Headers are optional for building. Even when using those packages to build the library, the client code can still choose to use the SDK version of those headers which works fine.

For MinGW and Linux/WSL, however, clients must always use the packages since the platform toolset don't include these headers (or at least not the right versions of them).
