### PR TITLE
Add GitHub Actions to validate UWP via CMake

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,6 +48,18 @@ jobs:
             build_type: x86-Release
             arch: amd64_x86
           - os: windows-2022
+            build_type: arm64-Debug
+            arch: amd64_arm64
+          - os: windows-2022
+            build_type: arm64-Release
+            arch: amd64_arm64
+          - os: windows-2022
+            build_type: arm64ec-Debug
+            arch: amd64_arm64
+          - os: windows-2022
+            build_type: arm64ec-Release
+            arch: amd64_arm64
+          - os: windows-2022
             build_type: x64-Debug-Clang
             arch: amd64
           - os: windows-2022
@@ -60,16 +72,10 @@ jobs:
             build_type: x86-Release-Clang
             arch: amd64_x86
           - os: windows-2022
-            build_type: arm64-Debug
+            build_type: arm64-Debug-Clang
             arch: amd64_arm64
           - os: windows-2022
-            build_type: arm64-Release
-            arch: amd64_arm64
-          - os: windows-2022
-            build_type: arm64ec-Debug
-            arch: amd64_arm64
-          - os: windows-2022
-            build_type: arm64ec-Release
+            build_type: arm64-Release-Clang
             arch: amd64_arm64
 
     steps:

--- a/.github/workflows/uwp.yml
+++ b/.github/workflows/uwp.yml
@@ -1,0 +1,71 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# https://go.microsoft.com/fwlink/?LinkID=324981
+
+name: 'CMake (UWP)'
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.nuget/*'
+      - build/*.cmd
+      - build/*.props
+      - build/*.ps1
+      - build/*.targets
+      - build/*.yml
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: windows-2022
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        build_type: [x64-Debug-UWP, x64-Release-UWP, x64-Debug-UWP-Clang, x64-Release-UWP-Clang]
+        arch: [amd64]
+        include:
+          - build_type: x86-Debug-UWP
+            arch: amd64_x86
+          - build_type: x86-Release-UWP
+            arch: amd64_x86
+          - build_type: x86-Debug-UWP-Clang
+            arch: amd64_x86
+          - build_type: x86-Release-UWP-Clang
+            arch: amd64_x86
+          - build_type: arm64-Debug-UWP
+            arch: amd64_arm64
+          - build_type: arm64-Release-UWP
+            arch: amd64_arm64
+          - build_type: arm64-Debug-UWP-Clang
+            arch: amd64_arm64
+          - build_type: arm64-Release-UWP-Clang
+            arch: amd64_arm64
+
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+    - name: 'Install Ninja'
+      run: choco install ninja
+
+    - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+      with:
+        arch: ${{ matrix.arch }}
+        uwp: true
+
+    - name: 'Configure CMake'
+      working-directory: ${{ github.workspace }}
+      run: cmake --preset=${{ matrix.build_type }}
+
+    - name: 'Build'
+      working-directory: ${{ github.workspace }}
+      run: cmake --build out\build\${{ matrix.build_type }}

--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -39,6 +39,15 @@ jobs:
           - os: windows-2022
             build_type: arm64-Debug-VCPKG
             arch: amd64_arm64
+          - os: windows-2022
+            build_type: arm64ec-Debug-VCPKG
+            arch: amd64_arm64
+          - os: windows-2022
+            build_type: x64-Debug-MinGW
+            arch: amd64
+          - os: windows-2022
+            build_type: x64-Release-MinGW
+            arch: amd64
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -55,7 +64,14 @@ jobs:
       run: |
         if ("${{ matrix.arch }}" -eq "amd64")
         {
-            echo "VCPKG_DEFAULT_TRIPLET=x64-windows" >> $env:GITHUB_ENV
+            if ("${{ matrix.build_type }}" -match "MinGW")
+            {
+                echo "VCPKG_DEFAULT_TRIPLET=x64-mingw-static" >> $env:GITHUB_ENV
+            }
+            else
+            {
+                echo "VCPKG_DEFAULT_TRIPLET=x64-windows" >> $env:GITHUB_ENV
+            }
         }
         elseif ("${{ matrix.arch }}" -eq "amd64_x86")
         {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -45,6 +45,10 @@
         "strategy": "external"
       },
       "cacheVariables": { "DIRECTX_ARCH": "arm64ec" },
+      "environment": {
+        "CFLAGS": "/arm64EC",
+        "CXXFLAGS": "/arm64EC"
+      },
       "hidden": true
     },
 
@@ -84,6 +88,22 @@
         "value": "host=x64",
         "strategy": "external"
       }
+    },
+    {
+      "name": "Clang-X86",
+      "environment": {
+        "CFLAGS": "-m32",
+        "CXXFLAGS": "-m32"
+      },
+      "hidden": true
+    },
+    {
+      "name": "Clang-AArch64",
+      "environment": {
+        "CFLAGS": "--target=arm64-pc-windows-msvc",
+        "CXXFLAGS": "--target=arm64-pc-windows-msvc"
+      },
+      "hidden": true
     },
     {
       "name": "GNUC",
@@ -145,7 +165,7 @@
       },
       "cacheVariables": {
         "VCPKG_TARGET_TRIPLET": "x86-mingw-static",
-        "VCPKG_HOST_TRIPLET": "x86-mingw-static"
+        "VCPKG_HOST_TRIPLET": "x64-windows"
       }
     },
     {
@@ -156,7 +176,7 @@
       },
       "cacheVariables": {
         "VCPKG_TARGET_TRIPLET": "x64-mingw-static",
-        "VCPKG_HOST_TRIPLET": "x64-mingw-static"
+        "VCPKG_HOST_TRIPLET": "x64-windows"
       }
     },
     {
@@ -207,8 +227,8 @@
     { "name": "x86-Release"    , "description": "MSVC for x86 (Release) with DX12", "inherits": [ "base", "x86", "Release", "MSVC" ] },
     { "name": "arm64-Debug"    , "description": "MSVC for ARM64 (Debug) with DX12", "inherits": [ "base", "ARM64", "Debug", "MSVC" ] },
     { "name": "arm64-Release"  , "description": "MSVC for ARM64 (Release) with DX12", "inherits": [ "base", "ARM64", "Release", "MSVC" ] },
-    { "name": "arm64ec-Debug"  , "description": "MSVC for ARM64EC (Debug) with DX12", "inherits": [ "base", "ARM64EC", "Debug", "MSVC" ], "environment": { "CXXFLAGS": "/arm64EC" }  },
-    { "name": "arm64ec-Release", "description": "MSVC for ARM64EC (Release) with DX12", "inherits": [ "base", "ARM64EC", "Release", "MSVC" ], "environment": { "CXXFLAGS": "/arm64EC" }  },
+    { "name": "arm64ec-Debug"  , "description": "MSVC for ARM64EC (Debug) with DX12", "inherits": [ "base", "ARM64EC", "Debug", "MSVC" ] },
+    { "name": "arm64ec-Release", "description": "MSVC for ARM64EC (Release) with DX12", "inherits": [ "base", "ARM64EC", "Release", "MSVC" ] },
 
     { "name": "x64-Debug-UWP"    , "description": "MSVC for x64 (Debug) for UWP", "inherits": [ "base", "x64", "Debug", "MSVC", "UWP" ] },
     { "name": "x64-Release-UWP"  , "description": "MSVC for x64 (Release) for UWP", "inherits": [ "base", "x64", "Release", "MSVC", "UWP" ] },
@@ -234,34 +254,34 @@
     { "name": "x86-Release-VCPKG"    , "description": "MSVC for x86 (Release) using VCPKG", "inherits": [ "base", "x86", "Release", "MSVC", "VCPKG" ] },
     { "name": "arm64-Debug-VCPKG"    , "description": "MSVC for ARM64 (Debug) using VCPKG", "inherits": [ "base", "ARM64", "Debug", "MSVC", "VCPKG" ] },
     { "name": "arm64-Release-VCPKG"  , "description": "MSVC for ARM64 (Release) using VCPKG", "inherits": [ "base", "ARM64", "Release", "MSVC", "VCPKG" ] },
-    { "name": "arm64ec-Debug-VCPKG"  , "description": "MSVC for ARM64EC (Debug) using VCPKG", "inherits": [ "base", "ARM64EC", "Debug", "MSVC", "VCPKG" ], "environment": { "CXXFLAGS": "/arm64EC" }, "cacheVariables": { "VCPKG_TARGET_TRIPLET": "arm64ec-windows" } },
-    { "name": "arm64ec-Release-VCPKG", "description": "MSVC for ARM64EC (Release) using VCPKG", "inherits": [ "base", "ARM64EC", "Release", "MSVC", "VCPKG" ], "environment": { "CXXFLAGS": "/arm64EC" }, "cacheVariables": { "VCPKG_TARGET_TRIPLET": "arm64ec-windows" } },
+    { "name": "arm64ec-Debug-VCPKG"  , "description": "MSVC for ARM64EC (Debug) using VCPKG", "inherits": [ "base", "ARM64EC", "Debug", "MSVC", "VCPKG" ], "cacheVariables": { "VCPKG_TARGET_TRIPLET": "arm64ec-windows" } },
+    { "name": "arm64ec-Release-VCPKG", "description": "MSVC for ARM64EC (Release) using VCPKG", "inherits": [ "base", "ARM64EC", "Release", "MSVC", "VCPKG" ], "cacheVariables": { "VCPKG_TARGET_TRIPLET": "arm64ec-windows" } },
 
     { "name": "x64-Debug-Clang"    , "description": "Clang/LLVM for x64 (Debug) with DX12", "inherits": [ "base", "x64", "Debug", "Clang" ] },
     { "name": "x64-Release-Clang"  , "description": "Clang/LLVM for x64 (Release) with DX12", "inherits": [ "base", "x64", "Release", "Clang" ] },
-    { "name": "x86-Debug-Clang"    , "description": "Clang/LLVM for x86 (Debug) with DX12", "inherits": [ "base", "x86", "Debug", "Clang" ], "environment": { "CXXFLAGS": "-m32" } },
-    { "name": "x86-Release-Clang"  , "description": "Clang/LLVM for x86 (Release) with DX12", "inherits": [ "base", "x86", "Release", "Clang" ], "environment": { "CXXFLAGS": "-m32" } },
-    { "name": "arm64-Debug-Clang"  , "description": "Clang/LLVM for AArch64 (Debug) with DX12", "inherits": [ "base", "ARM64", "Debug", "Clang" ], "environment": { "CXXFLAGS": "--target=arm64-pc-windows-msvc" } },
-    { "name": "arm64-Release-Clang", "description": "Clang/LLVM for AArch64 (Release) with DX12", "inherits": [ "base", "ARM64", "Release", "Clang" ], "environment": { "CXXFLAGS": "--target=arm64-pc-windows-msvc" } },
+    { "name": "x86-Debug-Clang"    , "description": "Clang/LLVM for x86 (Debug) with DX12", "inherits": [ "base", "x86", "Debug", "Clang", "Clang-X86" ] },
+    { "name": "x86-Release-Clang"  , "description": "Clang/LLVM for x86 (Release) with DX12", "inherits": [ "base", "x86", "Release", "Clang", "Clang-X86" ] },
+    { "name": "arm64-Debug-Clang"  , "description": "Clang/LLVM for AArch64 (Debug) with DX12", "inherits": [ "base", "ARM64", "Debug", "Clang", "Clang-AArch64" ] },
+    { "name": "arm64-Release-Clang", "description": "Clang/LLVM for AArch64 (Release) with DX12", "inherits": [ "base", "ARM64", "Release", "Clang", "Clang-AArch64" ] },
 
     { "name": "x64-Debug-Clang-VCPKG"    , "description": "Clang/LLVM for x64 (Debug) using VCPKG", "inherits": [ "base", "x64", "Debug", "Clang", "VCPKG" ] },
     { "name": "x64-Release-Clang-VCPKG"  , "description": "Clang/LLVM for x64 (Release) using VCPKG", "inherits": [ "base", "x64", "Release", "Clang", "VCPKG" ] },
-    { "name": "x86-Debug-Clang-VCPKG"    , "description": "Clang/LLVM for x86 (Debug) using VCPKG", "inherits": [ "base", "x86", "Debug", "Clang", "VCPKG" ], "environment": { "CXXFLAGS": "-m32" } },
-    { "name": "x86-Release-Clang-VCPKG"  , "description": "Clang/LLVM for x86 (Release) using VCPKG", "inherits": [ "base", "x86", "Release", "Clang", "VCPKG" ], "environment": { "CXXFLAGS": "-m32" } },
-    { "name": "arm64-Debug-Clang-VCPKG"  , "description": "Clang/LLVM for AArch64 (Debug) using VCPKG", "inherits": [ "base", "ARM64", "Debug", "Clang", "VCPKG" ], "environment": { "CXXFLAGS": "--target=arm64-pc-windows-msvc" } },
-    { "name": "arm64-Release-Clang-VCPKG", "description": "Clang/LLVM for AArch64 (Release) using VCPKG", "inherits": [ "base", "ARM64", "Release", "Clang", "VCPKG" ], "environment": { "CXXFLAGS": "--target=arm64-pc-windows-msvc" } },
+    { "name": "x86-Debug-Clang-VCPKG"    , "description": "Clang/LLVM for x86 (Debug) using VCPKG", "inherits": [ "base", "x86", "Debug", "Clang", "Clang-X86", "VCPKG" ] },
+    { "name": "x86-Release-Clang-VCPKG"  , "description": "Clang/LLVM for x86 (Release) using VCPKG", "inherits": [ "base", "x86", "Release", "Clang", "Clang-X86", "VCPKG" ] },
+    { "name": "arm64-Debug-Clang-VCPKG"  , "description": "Clang/LLVM for AArch64 (Debug) using VCPKG", "inherits": [ "base", "ARM64", "Debug", "Clang", "VCPKG", "Clang-AArch64" ] },
+    { "name": "arm64-Release-Clang-VCPKG", "description": "Clang/LLVM for AArch64 (Release) using VCPKG", "inherits": [ "base", "ARM64", "Release", "Clang", "VCPKG", "Clang-AArch64" ] },
 
     { "name": "x64-Debug-UWP-Clang"    , "description": "Clang/LLVM for x64 (Debug) for UWP", "inherits": [ "base", "x64", "Debug", "Clang", "UWP" ] },
     { "name": "x64-Release-UWP-Clang"  , "description": "Clang/LLVM for x64 (Release) for UWP", "inherits": [ "base", "x64", "Release", "Clang", "UWP" ] },
-    { "name": "x86-Debug-UWP-Clang"    , "description": "Clang/LLVM for x86 (Debug) for UWP", "inherits": [ "base", "x86", "Debug", "Clang", "UWP" ], "environment": { "CXXFLAGS": "-m32" } },
-    { "name": "x86-Release-UWP-Clang"  , "description": "Clang/LLVM for x86 (Release) for UWP", "inherits": [ "base", "x86", "Release", "Clang", "UWP" ], "environment": { "CXXFLAGS": "-m32" } },
-    { "name": "arm64-Debug-UWP-Clang"  , "description": "Clang/LLVM for AArch64 (Debug) for UWP", "inherits": [ "base", "ARM64", "Debug", "Clang", "UWP" ], "environment": { "CXXFLAGS": "--target=arm64-pc-windows-msvc" } },
-    { "name": "arm64-Release-UWP-Clang", "description": "Clang/LLVM for AArch64 (Release) for UWP", "inherits": [ "base", "ARM64", "Release", "Clang", "UWP" ], "environment": { "CXXFLAGS": "--target=arm64-pc-windows-msvc" } },
+    { "name": "x86-Debug-UWP-Clang"    , "description": "Clang/LLVM for x86 (Debug) for UWP", "inherits": [ "base", "x86", "Debug", "Clang", "Clang-X86", "UWP" ] },
+    { "name": "x86-Release-UWP-Clang"  , "description": "Clang/LLVM for x86 (Release) for UWP", "inherits": [ "base", "x86", "Release", "Clang", "Clang-X86", "UWP" ] },
+    { "name": "arm64-Debug-UWP-Clang"  , "description": "Clang/LLVM for AArch64 (Debug) for UWP", "inherits": [ "base", "ARM64", "Debug", "Clang", "Clang-AArch64", "UWP" ] },
+    { "name": "arm64-Release-UWP-Clang", "description": "Clang/LLVM for AArch64 (Release) for UWP", "inherits": [ "base", "ARM64", "Release", "Clang", "Clang-AArch64", "UWP" ] },
 
     { "name": "x64-Debug-Win7-Clang"    , "description": "Clang/LLVM for x64 (Debug) for Windows 7", "inherits": [ "base", "x64", "Debug", "Clang", "Win7" ] },
     { "name": "x64-Release-Win7-Clang"  , "description": "Clang/LLVM for x64 (Release) for Windows 7", "inherits": [ "base", "x64", "Release", "Clang", "Win7" ] },
-    { "name": "x86-Debug-Win7-Clang"    , "description": "Clang/LLVM for x86 (Debug) for Windows 7", "inherits": [ "base", "x86", "Debug", "Clang", "Win7" ], "environment": { "CXXFLAGS": "-m32" } },
-    { "name": "x86-Release-Win7-Clang"  , "description": "Clang/LLVM for x86 (Release) for Windows 7", "inherits": [ "base", "x86", "Release", "Clang", "Win7" ], "environment": { "CXXFLAGS": "-m32" } },
+    { "name": "x86-Debug-Win7-Clang"    , "description": "Clang/LLVM for x86 (Debug) for Windows 7", "inherits": [ "base", "x86", "Debug", "Clang", "Clang-X86", "Win7" ] },
+    { "name": "x86-Release-Win7-Clang"  , "description": "Clang/LLVM for x86 (Release) for Windows 7", "inherits": [ "base", "x86", "Release", "Clang", "Clang-X86", "Win7" ] },
 
     { "name": "x64-Debug-Scarlett-Clang"  , "description": "Clang/LLVM for x64 (Debug) for Xbox Series X|S", "inherits": [ "base", "x64", "Debug", "Clang", "Scarlett" ] },
     { "name": "x64-Release-Scarlett-Clang", "description": "Clang/LLVM for x64 (Release) for Xbox Series X|S", "inherits": [ "base", "x64", "Release", "Clang", "Scarlett" ] },


### PR DESCRIPTION
Also adds MinGW64 and AArch64 (ARM64) Clang coverage to Git Hub Actions.

