### PR TITLE
GHA Linux runner updated

### DIFF
--- a/.github/workflows/wsl.yml
+++ b/.github/workflows/wsl.yml
@@ -29,7 +29,7 @@ jobs:
 
       matrix:
         build_type: [x64-Debug-Linux, x64-Release-Linux]
-        gcc: [10, 11, 12]
+        gcc: [12, 13, 14]
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
GNUC 10 and 11 not included in Linux runner image anymore. Now has GNUC 12, 13, and 14.