### PR TITLE
Code review for const auto vs auto const

### DIFF
--- a/DirectXMesh/DirectXMeshConcat.cpp
+++ b/DirectXMesh/DirectXMeshConcat.cpp
@@ -41,13 +41,13 @@ HRESULT __cdecl DirectX::ConcatenateMesh(
     if (newFaceCount >= UINT32_MAX || newVertCount >= UINT32_MAX)
         return E_FAIL;
 
-    auto const baseFace = static_cast<uint32_t>(totalFaces);
+    const auto baseFace = static_cast<uint32_t>(totalFaces);
     for (size_t j = 0; j < nFaces; ++j)
     {
         faceDestMap[j] = baseFace + static_cast<uint32_t>(j);
     }
 
-    auto const baseVert = static_cast<uint32_t>(totalVerts);
+    const auto baseVert = static_cast<uint32_t>(totalVerts);
     for (size_t j = 0; j < nVerts; ++j)
     {
         vertexDestMap[j] = baseVert + static_cast<uint32_t>(j);

--- a/DirectXMesh/DirectXMeshVBReader.cpp
+++ b/DirectXMesh/DirectXMeshVBReader.cpp
@@ -452,7 +452,7 @@ HRESULT VBReader::Impl::Read(XMVECTOR* buffer, const char* semanticName, unsigne
         {
             if ((ptr + sizeof(uint16_t)) > eptr)
                 return E_UNEXPECTED;
-            auto const i = *reinterpret_cast<const uint16_t*>(ptr);
+            const auto i = *reinterpret_cast<const uint16_t*>(ptr);
             float f = static_cast<float>(i) / 65535.f;
             if (x2bias)
             {
@@ -469,7 +469,7 @@ HRESULT VBReader::Impl::Read(XMVECTOR* buffer, const char* semanticName, unsigne
         {
             if ((ptr + sizeof(uint16_t)) > eptr)
                 return E_UNEXPECTED;
-            auto const i = *reinterpret_cast<const uint16_t*>(ptr);
+            const auto i = *reinterpret_cast<const uint16_t*>(ptr);
             *buffer++ = XMVectorSet(static_cast<float>(i), 0.f, 0.f, 0.f);
             ptr += stride;
         }
@@ -480,7 +480,7 @@ HRESULT VBReader::Impl::Read(XMVECTOR* buffer, const char* semanticName, unsigne
         {
             if ((ptr + sizeof(int16_t)) > eptr)
                 return E_UNEXPECTED;
-            auto const i = *reinterpret_cast<const int16_t*>(ptr);
+            const auto i = *reinterpret_cast<const int16_t*>(ptr);
             *buffer++ = XMVectorSet(static_cast<float>(i) / 32767.f, 0.f, 0.f, 0.f);
             ptr += stride;
         }
@@ -491,7 +491,7 @@ HRESULT VBReader::Impl::Read(XMVECTOR* buffer, const char* semanticName, unsigne
         {
             if ((ptr + sizeof(int16_t)) > eptr)
                 return E_UNEXPECTED;
-            auto const i = *reinterpret_cast<const int16_t*>(ptr);
+            const auto i = *reinterpret_cast<const int16_t*>(ptr);
             *buffer++ = XMVectorSet(static_cast<float>(i), 0.f, 0.f, 0.f);
             ptr += stride;
         }
@@ -530,7 +530,7 @@ HRESULT VBReader::Impl::Read(XMVECTOR* buffer, const char* semanticName, unsigne
         {
             if ((ptr + sizeof(int8_t)) > eptr)
                 return E_UNEXPECTED;
-            auto const i = *reinterpret_cast<const int8_t*>(ptr);
+            const auto i = *reinterpret_cast<const int8_t*>(ptr);
             *buffer++ = XMVectorSet(static_cast<float>(i) / 127.f, 0.f, 0.f, 0.f);
             ptr += stride;
         }
@@ -541,7 +541,7 @@ HRESULT VBReader::Impl::Read(XMVECTOR* buffer, const char* semanticName, unsigne
         {
             if ((ptr + sizeof(int8_t)) > eptr)
                 return E_UNEXPECTED;
-            auto const i = *reinterpret_cast<const int8_t*>(ptr);
+            const auto i = *reinterpret_cast<const int8_t*>(ptr);
             *buffer++ = XMVectorSet(static_cast<float>(i), 0.f, 0.f, 0.f);
             ptr += stride;
         }

--- a/DirectXMesh/DirectXMeshletGenerator.cpp
+++ b/DirectXMesh/DirectXMeshletGenerator.cpp
@@ -674,7 +674,7 @@ namespace
                     return E_UNEXPECTED;
                 }
 
-                auto const primitive = primitiveIndices[m.PrimOffset + i];
+                const auto primitive = primitiveIndices[m.PrimOffset + i];
 
                 const XMVECTOR p0 = XMLoadFloat3(&vertices[primitive.i0]);
 

--- a/Meshconvert/Mesh.cpp
+++ b/Meshconvert/Mesh.cpp
@@ -74,7 +74,7 @@ namespace
 
         if (length > 0)
         {
-            auto const bytes = static_cast<DWORD>(sizeof(wchar_t) * length);
+            const auto bytes = static_cast<DWORD>(sizeof(wchar_t) * length);
 
             if (!WriteFile(hFile, value, bytes, &bytesWritten, nullptr))
                 return HRESULT_FROM_WIN32(GetLastError());
@@ -1084,7 +1084,7 @@ HRESULT Mesh::ExportToVBO(const wchar_t* szFileName) const noexcept
     if (FAILED(hr))
         return hr;
 
-    auto const vertSize = static_cast<DWORD>(sizeof(vertex_t) * header.numVertices);
+    const auto vertSize = static_cast<DWORD>(sizeof(vertex_t) * header.numVertices);
 
     DWORD bytesWritten;
     if (!WriteFile(hFile.get(), vb.get(), vertSize, &bytesWritten, nullptr))
@@ -1093,7 +1093,7 @@ HRESULT Mesh::ExportToVBO(const wchar_t* szFileName) const noexcept
     if (bytesWritten != vertSize)
         return E_FAIL;
 
-    auto const indexSize = static_cast<DWORD>(sizeof(uint16_t) * header.numIndices);
+    const auto indexSize = static_cast<DWORD>(sizeof(uint16_t) * header.numIndices);
 
     if (!WriteFile(hFile.get(), ib.get(), indexSize, &bytesWritten, nullptr))
         return HRESULT_FROM_WIN32(GetLastError());
@@ -1165,7 +1165,7 @@ HRESULT Mesh::CreateFromVBO(const wchar_t* szFileName, std::unique_ptr<Mesh>& re
     if (!vb || !ib)
         return E_OUTOFMEMORY;
 
-    auto const vertSize = static_cast<DWORD>(sizeof(vertex_t) * header.numVertices);
+    const auto vertSize = static_cast<DWORD>(sizeof(vertex_t) * header.numVertices);
 
     if (!ReadFile(hFile.get(), vb.get(), vertSize, &bytesRead, nullptr))
     {
@@ -1175,7 +1175,7 @@ HRESULT Mesh::CreateFromVBO(const wchar_t* szFileName, std::unique_ptr<Mesh>& re
     if (bytesRead != vertSize)
         return E_FAIL;
 
-    auto const indexSize = static_cast<DWORD>(sizeof(uint16_t) * header.numIndices);
+    const auto indexSize = static_cast<DWORD>(sizeof(uint16_t) * header.numIndices);
 
     if (!ReadFile(hFile.get(), ib.get(), indexSize, &bytesRead, nullptr))
     {
@@ -1660,7 +1660,7 @@ HRESULT Mesh::ExportToCMO(const wchar_t* szFileName, size_t nMaterials, const Ma
     if (FAILED(hr))
         return hr;
 
-    auto const indexSize = static_cast<DWORD>(sizeof(uint16_t) * nIndices);
+    const auto indexSize = static_cast<DWORD>(sizeof(uint16_t) * nIndices);
 
     DWORD bytesWritten;
     if (!WriteFile(hFile.get(), ib.get(), indexSize, &bytesWritten, nullptr))
@@ -1680,7 +1680,7 @@ HRESULT Mesh::ExportToCMO(const wchar_t* szFileName, size_t nMaterials, const Ma
     if (FAILED(hr))
         return hr;
 
-    auto const vertSize = static_cast<DWORD>(sizeof(Vertex) * mnVerts);
+    const auto vertSize = static_cast<DWORD>(sizeof(Vertex) * mnVerts);
 
     if (!WriteFile(hFile.get(), vb.get(), vertSize, &bytesWritten, nullptr))
         return HRESULT_FROM_WIN32(GetLastError());
@@ -1701,7 +1701,7 @@ HRESULT Mesh::ExportToCMO(const wchar_t* szFileName, size_t nMaterials, const Ma
         if (FAILED(hr))
             return hr;
 
-        auto const skinVertSize = static_cast<DWORD>(sizeof(SkinningVertex) * mnVerts);
+        const auto skinVertSize = static_cast<DWORD>(sizeof(SkinningVertex) * mnVerts);
 
         if (!WriteFile(hFile.get(), vbSkin.get(), skinVertSize, &bytesWritten, nullptr))
             return HRESULT_FROM_WIN32(GetLastError());

--- a/Meshconvert/Meshconvert.cpp
+++ b/Meshconvert/Meshconvert.cpp
@@ -631,7 +631,7 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
     for (auto pConv = conversion.begin(); pConv != conversion.end(); ++pConv)
     {
         std::filesystem::path curpath(pConv->szSrc);
-        auto const ext = curpath.extension();
+        const auto ext = curpath.extension();
 
         if (pConv != conversion.begin())
             wprintf(L"\n");


### PR DESCRIPTION
Both ``const auto`` and ``auto const`` are equivalent in terms of the C++ compiler parser, but general coding guidelines suggest using ``const auto``. The primary reason for this PR is to be consistent since the codebase was using both.