### PR TITLE
Update ADO coverage for clang v12

### DIFF
--- a/build/DirectXMesh-GitHub-CMake.yml
+++ b/build/DirectXMesh-GitHub-CMake.yml
@@ -98,102 +98,62 @@ jobs:
       cwd: '$(Build.SourcesDirectory)'
       cmakeArgs: --build out2 -v --config RelWithDebInfo
   - task: CMake@1
-    displayName: 'CMake (MSVC): Config ARM64'
-    inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A ARM64 -B out3 -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK) -DBUILD_DX12=OFF'
-  - task: CMake@1
-    displayName: 'CMake (MSVC): Build ARM64 Debug'
-    inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out3 -v --config Debug
-  - task: CMake@1
-    displayName: 'CMake (MSVC): Build ARM64 Release'
-    inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out3 -v --config RelWithDebInfo
-  - task: CMake@1
     displayName: 'CMake (UWP): Config x64'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out4 -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=10.0'
+      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out3 -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=10.0'
   - task: CMake@1
     displayName: 'CMake (UWP): Build x64'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out4 -v
+      cmakeArgs: --build out3 -v
   - task: CMake@1
     displayName: 'CMake (ClangCl): Config x64'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -T clangcl -B out6 -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)'
+      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -T clangcl -B out4 -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)'
   - task: CMake@1
     displayName: 'CMake (ClangCl): Build x64 Debug'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out6 -v --config Debug
+      cmakeArgs: --build out4 -v --config Debug
   - task: CMake@1
     displayName: 'CMake (ClangCl): Build x64 Release'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out6 -v --config RelWithDebInfo
-  - task: CMake@1
-    displayName: 'CMake (ClangCl): Config ARM64'
-    inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A ARM64 -T clangcl -B out7 -DCMAKE_SYSTEM_VERSION=$(WIN11_SDK)'
-  - task: CMake@1
-    displayName: 'CMake (ClangCl): Build ARM64'
-    inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out7 -v --config Debug
+      cmakeArgs: --build out4 -v --config RelWithDebInfo
   - task: CMake@1
     displayName: 'CMake (Win10): Config'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out8 -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK) -DBUILD_DX12=ON'
+      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out5 -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK) -DBUILD_DX12=ON'
   - task: CMake@1
     displayName: 'CMake (Win10): Build'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out8 -v --config Debug
+      cmakeArgs: --build out5 -v --config Debug
   - task: CMake@1
     displayName: 'CMake (MSVC Spectre): Config x64'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out9 -DENABLE_SPECTRE_MITIGATION=ON -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK) -DBUILD_DX12=OFF'
+      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out6 -DENABLE_SPECTRE_MITIGATION=ON -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK) -DBUILD_DX12=OFF'
   - task: CMake@1
     displayName: 'CMake (MSVC Spectre): Build x64 Debug'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out9 -v --config Debug
+      cmakeArgs: --build out6 -v --config Debug
   - task: CMake@1
     displayName: 'CMake (MSVC Spectre): Build x64 Release'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out9 -v --config RelWithDebInfo
-  - task: CMake@1
-    displayName: 'CMake (MSVC Spectre): Config ARM64'
-    inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A ARM64 -B out10 -DENABLE_SPECTRE_MITIGATION=ON -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK) -DBUILD_DX12=OFF'
-  - task: CMake@1
-    displayName: 'CMake (MSVC Spectre): Build ARM64 Debug'
-    inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out10 -v --config Debug
-  - task: CMake@1
-    displayName: 'CMake (MSVC Spectre): Build ARM64 Release'
-    inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out10 -v --config RelWithDebInfo
+      cmakeArgs: --build out6 -v --config RelWithDebInfo
   - task: CMake@1
     displayName: 'CMake (Win10 Spectre): Config'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out11 -DENABLE_SPECTRE_MITIGATION=ON -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK) -DBUILD_DX12=ON'
+      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out7 -DENABLE_SPECTRE_MITIGATION=ON -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK) -DBUILD_DX12=ON'
   - task: CMake@1
     displayName: 'CMake (Win10 Spectre): Build'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out11 -v --config Debug
+      cmakeArgs: --build out7 -v --config Debug

--- a/build/DirectXMesh-GitHub-Test.yml
+++ b/build/DirectXMesh-GitHub-Test.yml
@@ -40,6 +40,7 @@ pool:
 
 variables:
   Codeql.Enabled: false
+  VC_PATH: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC'
 
 jobs:
 - job: DESKTOP_BUILD
@@ -122,19 +123,85 @@ jobs:
       msbuildArgs: /p:PreferredToolArchitecture=x64
       platform: x64
       configuration: Release
-  - task: VSBuild@1
-    displayName: Build solution DirectXMesh_Tests_Desktop_2019_Win10.sln arm64dbg
+
+- job: CMAKE_BUILD_X64
+  displayName: 'CMake for X64 BUILD_TESTING=ON'
+  timeoutInMinutes: 60
+  workspace:
+    clean: all
+  steps:
+  - checkout: self
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
+    displayName: Fetch Tests
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
+  - task: CmdLine@2
+    displayName: Setup environment for CMake to use VS
     inputs:
-      solution: Tests/DirectXMesh_Tests_Desktop_2019_Win10.sln
-      vsVersion: 16.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXMesh_Tests_Desktop_2019_Win10.sln arm64rel
+      script: |
+        call "$(VC_PATH)\Auxiliary\Build\vcvars64.bat"
+        echo ##vso[task.setvariable variable=WindowsSdkVerBinPath;]%WindowsSdkVerBinPath%
+        echo ##vso[task.prependpath]%VSINSTALLDIR%Common7\IDE\CommonExtensions\Microsoft\CMake\Ninja
+        echo ##vso[task.prependpath]%VCINSTALLDIR%Tools\Llvm\x64\bin
+        echo ##vso[task.prependpath]%WindowsSdkBinPath%x64
+        echo ##vso[task.prependpath]%WindowsSdkVerBinPath%x64
+        echo ##vso[task.prependpath]%VCToolsInstallDir%bin\Hostx64\x64
+        echo ##vso[task.setvariable variable=EXTERNAL_INCLUDE;]%EXTERNAL_INCLUDE%
+        echo ##vso[task.setvariable variable=INCLUDE;]%INCLUDE%
+        echo ##vso[task.setvariable variable=LIB;]%LIB%
+
+  - task: CMake@1
+    displayName: CMake (MSVC; x64-Debug) Config
     inputs:
-      solution: Tests/DirectXMesh_Tests_Desktop_2019_Win10.sln
-      vsVersion: 16.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Release
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --preset=x64-Debug
+  - task: CMake@1
+    displayName: CMake (MSVC; x64-Debug) Build
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out/build/x64-Debug -v
+  - task: DeleteFiles@1
+    inputs:
+      Contents: 'out'
+  - task: CMake@1
+    displayName: CMake (MSVC; x64-Release) Config
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --preset=x64-Release
+  - task: CMake@1
+    displayName: CMake (MSVC; x64-Release) Build
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out/build/x64-Release -v
+  - task: DeleteFiles@1
+    inputs:
+      Contents: 'out'
+  - task: CMake@1
+    displayName: CMake (clang/LLVM; x64-Debug) Config
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --preset=x64-Debug-Clang
+  - task: CMake@1
+    displayName: CMake (clang/LLVM; x64-Debug) Build
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out/build/x64-Debug-Clang -v
+  - task: DeleteFiles@1
+    inputs:
+      Contents: 'out'
+  - task: CMake@1
+    displayName: CMake (clang/LLVM; x64-Release) Config
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --preset=x64-Release-Clang
+  - task: CMake@1
+    displayName: CMake (clang/LLVM; x64-Release) Build
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out/build/x64-Release-Clang -v

--- a/build/DirectXMesh-GitHub.yml
+++ b/build/DirectXMesh-GitHub.yml
@@ -101,20 +101,6 @@ jobs:
       msbuildArgs: /p:PreferredToolArchitecture=x64
       platform: x64
       configuration: Release
-  - task: VSBuild@1
-    displayName: Build solution DirectXMesh_Desktop_2019_Win10.sln arm64dbg
-    inputs:
-      solution: DirectXMesh_Desktop_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXMesh_Desktop_2019_Win10.sln arm64rel
-    inputs:
-      solution: DirectXMesh_Desktop_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Release
 
 - job: DESKTOP_BUILD_SPECTRE
   displayName: 'Win32 Desktop (Spectre-mitigated)'
@@ -179,18 +165,4 @@ jobs:
       solution: DirectXMesh_Desktop_2019_Win10.sln
       msbuildArgs: /p:PreferredToolArchitecture=x64 /p:SpectreMitigation=Spectre
       platform: x64
-      configuration: Release
-  - task: VSBuild@1
-    displayName: Build solution DirectXMesh_Desktop_2019_Win10.sln arm64dbg
-    inputs:
-      solution: DirectXMesh_Desktop_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:SpectreMitigation=Spectre
-      platform: ARM64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXMesh_Desktop_2019_Win10.sln arm64rel
-    inputs:
-      solution: DirectXMesh_Desktop_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:SpectreMitigation=Spectre
-      platform: ARM64
       configuration: Release


### PR DESCRIPTION
Remove cases of building for ARM64 with VS 2019 due to changes to Windows SDK (26100).