### PR TITLE
March 24, 2025

### DIFF
--- a/.nuget/directxmesh_desktop_2019.nuspec
+++ b/.nuget/directxmesh_desktop_2019.nuspec
@@ -10,7 +10,7 @@
         <description>This version is for Windows desktop applications using Visual Studio 2019 (16.11) or Visual Studio 2022 on Windows 8.1 or later.
 
 DirectXMesh, a shared source library for performing various geometry content processing operations including generating normals and tangent frames, triangle adjacency computations, vertex cache optimization, and meshlet generation.</description>
-        <releaseNotes>Matches the October 28, 2024 release on GitHub.</releaseNotes>
+        <releaseNotes>Matches the March 24, 2025 release on GitHub.</releaseNotes>
         <projectUrl>http://go.microsoft.com/fwlink/?LinkID=324981</projectUrl>
         <repository type="git" url="https://github.com/microsoft/DirectXMesh.git" />
         <icon>images\icon.jpg</icon>

--- a/.nuget/directxmesh_desktop_win10.nuspec
+++ b/.nuget/directxmesh_desktop_win10.nuspec
@@ -10,7 +10,7 @@
         <description>This version is for Windows desktop applications using Visual Studio 2022 on Windows 10 / Windows 11 including both DirectX 11 and DirectX 12.
 
 DirectXMesh, a shared source library for performing various geometry content processing operations including generating normals and tangent frames, triangle adjacency computations, vertex cache optimization, and meshlet generation.</description>
-        <releaseNotes>Matches the October 28, 2024 release on GitHub.</releaseNotes>
+        <releaseNotes>Matches the March 24, 2025 release on GitHub.</releaseNotes>
         <projectUrl>http://go.microsoft.com/fwlink/?LinkID=324981</projectUrl>
         <repository type="git" url="https://github.com/microsoft/DirectXMesh.git" />
         <icon>images\icon.jpg</icon>

--- a/.nuget/directxmesh_uwp.nuspec
+++ b/.nuget/directxmesh_uwp.nuspec
@@ -10,7 +10,7 @@
         <description>This version is for Universal Windows Platform apps on Windows 10 / Windows 11 using Visual Studio 2022.
 
 DirectXMesh, a shared source library for performing various geometry content processing operations including generating normals and tangent frames, triangle adjacency computations, vertex cache optimization, and meshlet generation.</description>
-        <releaseNotes>Matches the October 28, 2024 release on GitHub.</releaseNotes>
+        <releaseNotes>Matches the March 24, 2025 release on GitHub.</releaseNotes>
         <projectUrl>http://go.microsoft.com/fwlink/?LinkID=324981</projectUrl>
         <repository type="git" url="https://github.com/microsoft/DirectXMesh.git" />
         <icon>images\icon.jpg</icon>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Releases available for download on [GitHub](https://github.com/microsoft/DirectX
 
 ## Release History
 
+### March 24, 2025
+* Retired support for Windows 7 and Windows 8.0
+* CMake project updates including support for BUILD_SHARED_LIBS (i.e. DLL vs. static library)
+
 ### October 28, 2024
 * All enums now use ``uint32_t`` as the underlying type rather than ``unsigned long`` or ``int``.
 * WaveFrontReader utililty moved into ``DX`` namespace

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 cmake_minimum_required (VERSION 3.20)
 
-set(DIRECTXMESH_VERSION 1.6.7)
+set(DIRECTXMESH_VERSION 1.6.8)
 
 project(DirectXMesh
   VERSION ${DIRECTXMESH_VERSION}

--- a/DirectXMesh/DirectXMesh.h
+++ b/DirectXMesh/DirectXMesh.h
@@ -40,7 +40,7 @@
 #include <DirectXCollision.h>
 #include <DirectXPackedVector.h>
 
-#define DIRECTX_MESH_VERSION 167
+#define DIRECTX_MESH_VERSION 168
 
 #ifdef DIRECTX_MESH_EXPORT
 #define DIRECTX_MESH_API __declspec(dllexport)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ http://go.microsoft.com/fwlink/?LinkID=324981
 
 Copyright (c) Microsoft Corporation.
 
-**October 28, 2024**
+**March 24, 2025**
 
 This package contains DirectXMesh, a shared source library for performing various geometry content processing operations including generating normals and tangent frames, triangle adjacency computations, vertex cache optimization, and meshlet generation.
 
@@ -53,6 +53,8 @@ For the latest version of DirectXMesh, bug reports, etc. please visit the projec
 FOR SECURITY ADVISORIES, see [GitHub](https://github.com/microsoft/DirectXMesh/security/advisories).
 
 For a full change history, see [CHANGELOG.md](https://github.com/microsoft/DirectXMesh/blob/main/CHANGELOG.md).
+
+* Starting with the March 2025 release, Windows 7 and Windows 8.0 support has been retired.
 
 * Starting with the June 2020 release, this library makes use of typed enum bitmask flags per the recommendation of the _C++ Standard_ section *17.5.2.1.3 Bitmask types*. This is consistent with Direct3D 12's use of the ``DEFINE_ENUM_FLAG_OPERATORS`` macro. This may have *breaking change* impacts to client code:
 


### PR DESCRIPTION
* Retired support for Windows 7 and Windows 8.0
* CMake project updates including support for BUILD_SHARED_LIBS (i.e. DLL vs. static library)