### PR TITLE
GitHub Actions windows-2019 runner is being retired

### DIFF
--- a/.github/workflows/bvt.yml
+++ b/.github/workflows/bvt.yml
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        toolver: [16.0, 17.0]
+        toolver: ['14.29', '']
         build_type: [x64-Debug, x64-Release]
         arch: [amd64]
 

--- a/.github/workflows/bvt.yml
+++ b/.github/workflows/bvt.yml
@@ -43,9 +43,16 @@ jobs:
       fail-fast: false
 
       matrix:
-        toolver: ['14.29', '']
+        toolver: ['14.29', '14']
         build_type: [x64-Debug, x64-Release]
         arch: [amd64]
+        include:
+          - toolver: '14.29'
+            build_type: x86-Debug
+            arch: amd64_x86
+          - toolver: '14'
+            build_type: x86-Debug
+            arch: amd64_x86
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/bvt.yml
+++ b/.github/workflows/bvt.yml
@@ -36,14 +36,14 @@ permissions:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    runs-on: windows-2022
     timeout-minutes: 20
 
     strategy:
       fail-fast: false
 
       matrix:
-        os: [windows-2019, windows-2022]
+        toolver: [16.0, 17.0]
         build_type: [x64-Debug, x64-Release]
         arch: [amd64]
 
@@ -63,6 +63,7 @@ jobs:
     - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
       with:
         arch: ${{ matrix.arch }}
+        toolset: ${{ matrix.toolver }}
 
     - name: 'Configure CMake'
       working-directory: ${{ github.workspace }}

--- a/.github/workflows/bvt.yml
+++ b/.github/workflows/bvt.yml
@@ -44,15 +44,8 @@ jobs:
 
       matrix:
         toolver: ['14.29', '14']
-        build_type: [x64-Debug, x64-Release]
+        build_type: [x64-Release]
         arch: [amd64]
-        include:
-          - toolver: '14.29'
-            build_type: x86-Debug
-            arch: amd64_x86
-          - toolver: '14'
-            build_type: x86-Debug
-            arch: amd64_x86
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,62 +36,62 @@ permissions:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    runs-on: windows-2022
 
     strategy:
       fail-fast: false
 
       matrix:
-        os: [windows-2019, windows-2022]
+        toolver: ['14.29', '14']
         build_type: [x64-Debug, x64-Release]
         arch: [amd64]
         include:
-          - os: windows-2019
+          - toolver: '14.29'
             build_type: x86-Debug
             arch: amd64_x86
-          - os: windows-2019
+          - toolver: '14.29'
             build_type: x86-Release
             arch: amd64_x86
-          - os: windows-2022
+          - toolver: '14'
             build_type: x86-Debug
             arch: amd64_x86
-          - os: windows-2022
+          - toolver: '14'
             build_type: x86-Release
             arch: amd64_x86
-          - os: windows-2022
+          - toolver: '14'
             build_type: arm64-Debug
             arch: amd64_arm64
-          - os: windows-2022
+          - toolver: '14'
             build_type: arm64-Release
             arch: amd64_arm64
-          - os: windows-2022
+          - toolver: '14'
             build_type: arm64ec-Debug
             arch: amd64_arm64
-          - os: windows-2022
+          - toolver: '14'
             build_type: arm64ec-Release
             arch: amd64_arm64
-          - os: windows-2022
+          - toolver: '14'
             build_type: x64-Debug-Win8
             arch: amd64
-          - os: windows-2022
+          - toolver: '14'
             build_type: x64-Release-Win8
             arch: amd64
-          - os: windows-2022
+          - toolver: '14'
             build_type: x64-Debug-Clang
             arch: amd64
-          - os: windows-2022
+          - toolver: '14'
             build_type: x64-Release-Clang
             arch: amd64
-          - os: windows-2022
+          - toolver: '14'
             build_type: x86-Debug-Clang
             arch: amd64_x86
-          - os: windows-2022
+          - toolver: '14'
             build_type: x86-Release-Clang
             arch: amd64_x86
-          - os: windows-2022
+          - toolver: '14'
             build_type: arm64-Debug-Clang
             arch: amd64_arm64
-          - os: windows-2022
+          - toolver: '14'
             build_type: arm64-Release-Clang
             arch: amd64_arm64
 
@@ -104,6 +104,7 @@ jobs:
     - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
       with:
         arch: ${{ matrix.arch }}
+        toolset: ${{ matrix.toolver }}
 
     - name: 'Configure CMake'
       working-directory: ${{ github.workspace }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,51 +39,51 @@ permissions:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    runs-on: windows-2022
     timeout-minutes: 20
 
     strategy:
       fail-fast: false
 
       matrix:
-        os: [windows-2019, windows-2022]
+        toolver: ['14.29', '14']
         build_type: [x64-Debug, x64-Release]
         arch: [amd64]
         include:
-          - os: windows-2019
+          - toolver: '14.29'
             build_type: x86-Debug
             arch: amd64_x86
-          - os: windows-2019
+          - toolver: '14.29'
             build_type: x86-Release
             arch: amd64_x86
-          - os: windows-2022
+          - toolver: '14'
             build_type: x86-Debug
             arch: amd64_x86
-          - os: windows-2022
+          - toolver: '14'
             build_type: x86-Release
             arch: amd64_x86
-          - os: windows-2022
+          - toolver: '14'
             build_type: x64-Debug-Clang
             arch: amd64
-          - os: windows-2022
+          - toolver: '14'
             build_type: x64-Release-Clang
             arch: amd64
-          - os: windows-2022
+          - toolver: '14'
             build_type: x86-Debug-Clang
             arch: amd64_x86
-          - os: windows-2022
+          - toolver: '14'
             build_type: x86-Release-Clang
             arch: amd64_x86
-          - os: windows-2022
+          - toolver: '14'
             build_type: arm64-Debug
             arch: amd64_arm64
-          - os: windows-2022
+          - toolver: '14'
             build_type: arm64-Release
             arch: amd64_arm64
-          - os: windows-2022
+          - toolver: '14'
             build_type: arm64ec-Debug
             arch: amd64_arm64
-          - os: windows-2022
+          - toolver: '14'
             build_type: arm64ec-Release
             arch: amd64_arm64
 
@@ -103,6 +103,7 @@ jobs:
     - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
       with:
         arch: ${{ matrix.arch }}
+        toolset: ${{ matrix.toolver }}
 
     - name: 'Configure CMake'
       working-directory: ${{ github.workspace }}

--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -34,46 +34,46 @@ permissions:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    runs-on: windows-2022
 
     strategy:
       fail-fast: false
 
       matrix:
-        os: [windows-2019, windows-2022]
+        toolver: ['14.29', '14']
         build_type: [x64-Debug-VCPKG]
         arch: [amd64]
         shared: [OFF]
         include:
-          - os: windows-2022
+          - toolver: '14'
             build_type: x64-Debug-Clang-VCPKG
             arch: amd64
             shared: OFF
-          - os: windows-2022
+          - toolver: '14'
             build_type: x86-Debug-VCPKG
             arch: amd64_x86
             shared: OFF
-          - os: windows-2022
+          - toolver: '14'
             build_type: arm64-Debug-VCPKG
             arch: amd64_arm64
             shared: OFF
-          - os: windows-2022
+          - toolver: '14'
             build_type: arm64ec-Debug-VCPKG
             arch: amd64_arm64
             shared: OFF
-          - os: windows-2022
+          - toolver: '14'
             build_type: x64-Debug-MinGW
             arch: amd64
             shared: OFF
-          - os: windows-2022
+          - toolver: '14'
             build_type: x64-Release-MinGW
             arch: amd64
             shared: OFF
-          - os: windows-2022
+          - toolver: '14'
             build_type: x64-Debug-MinGW
             arch: amd64
             shared: ON
-          - os: windows-2022
+          - toolver: '14'
             build_type: x64-Release-MinGW
             arch: amd64
             shared: ON
@@ -87,6 +87,7 @@ jobs:
     - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
       with:
         arch: ${{ matrix.arch }}
+        toolset: ${{ matrix.toolver }}
 
     - name: 'Set triplet'
       shell: pwsh

--- a/.github/workflows/wsl.yml
+++ b/.github/workflows/wsl.yml
@@ -31,6 +31,9 @@ on:
       - build/*.targets
       - build/*.yml
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Switched all impacted pipelines to use *windows-2022*, but I still make use of v142 toolset for validation of the "VS 2019 (16.11)" compiler.