### PR TITLE
Fix adjacency guard condition causing subscript out of range

### DIFF
--- a/DirectXMesh/DirectXMeshletGenerator.cpp
+++ b/DirectXMesh/DirectXMeshletGenerator.cpp
@@ -355,7 +355,7 @@ namespace
                         continue;
 
                     // Primitive is outside the subset
-                    if (adj[i] < subset.first || adj[i] > endIndex)
+                    if (adj[i] < subset.first || adj[i] >= endIndex)
                         continue;
 
                     // Already processed triangle


### PR DESCRIPTION
fixes https://github.com/microsoft/DirectXMesh/issues/235

if value behind adj[i] is equal to endIndex, we are outside the subset.