### PR TITLE
Fix /analyze warning

### DIFF
--- a/DirectXMesh/DirectXMeshUtil.cpp
+++ b/DirectXMesh/DirectXMeshUtil.cpp
@@ -270,14 +270,14 @@ void DirectX::ComputeInputLayout(
 {
     assert(IsValid(vbDecl, nDecl));
 
-    if (!vbDecl || !nDecl)
-        return;
-
     if (offsets)
         memset(offsets, 0, sizeof(uint32_t) * nDecl);
 
     if (strides)
         memset(strides, 0, sizeof(uint32_t) * D3D11_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT);
+
+    if (!vbDecl || !nDecl)
+        return;
 
     uint32_t prevABO[D3D11_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT];
     memset(prevABO, 0, sizeof(uint32_t) * D3D11_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT);
@@ -337,14 +337,14 @@ void DirectX::ComputeInputLayout(const D3D12_INPUT_LAYOUT_DESC& vbDecl,
 {
     assert(IsValid(vbDecl));
 
-    if (!vbDecl.pInputElementDescs || !vbDecl.NumElements)
-        return;
-
     if (offsets)
         memset(offsets, 0, sizeof(uint32_t) * vbDecl.NumElements);
 
     if (strides)
         memset(strides, 0, sizeof(uint32_t) * D3D12_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT);
+
+    if (!vbDecl.pInputElementDescs || !vbDecl.NumElements)
+        return;
 
     uint32_t prevABO[D3D12_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT] = {};
 


### PR DESCRIPTION
PR #243 introduced this PREFIX warning:

> DirectXMeshUtil.cpp(267) : warning C6101: Returning uninitialized memory '*strides'.  A successful path through the function does not set the named _Out_ parameter. : Lines: 267, 271, 273, 274, 267

Which this PR fixes.