### PR TITLE
Upgrade to CMake 3.21

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-cmake_minimum_required (VERSION 3.20)
+cmake_minimum_required (VERSION 3.21)
 
 set(DIRECTXMESH_VERSION 1.6.9)
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": 2,
+  "version": 3,
   "configurePresets": [
     {
       "name": "base",
@@ -8,7 +8,7 @@
       "generator": "Ninja",
       "hidden": true,
       "binaryDir": "${sourceDir}/out/build/${presetName}",
-      "cacheVariables": { "CMAKE_INSTALL_PREFIX": "${sourceDir}/out/install/${presetName}" }
+      "installDir": "${sourceDir}/out/install/${presetName}"
     },
 
     {
@@ -149,12 +149,7 @@
     },
     {
       "name": "VCPKG",
-      "cacheVariables": {
-        "CMAKE_TOOLCHAIN_FILE": {
-          "value": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
-          "type": "FILEPATH"
-        }
-      },
+      "toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
       "hidden": true
     },
     {

--- a/DirectXMesh/DirectXMeshClean.cpp
+++ b/DirectXMesh/DirectXMeshClean.cpp
@@ -24,7 +24,7 @@ namespace
         _Inout_ std::vector<uint32_t>& dupVerts, bool breakBowties)
     {
         if (!adjacency && !attributes)
-            return E_INVALIDARG;
+            return E_POINTER;
 
         if ((uint64_t(nFaces) * 3) >= UINT32_MAX)
             return HRESULT_E_ARITHMETIC_OVERFLOW;

--- a/DirectXMesh/DirectXMeshOptimizeTVC.cpp
+++ b/DirectXMesh/DirectXMeshOptimizeTVC.cpp
@@ -35,8 +35,8 @@ namespace
             _In_reads_(nFaces * 3) const uint32_t* adjacency,
             const std::vector<std::pair<size_t, size_t>>& subsets)
         {
-            if (!indices || !nFaces || !adjacency || subsets.empty())
-                return E_INVALIDARG;
+            if (!indices || !adjacency)
+                return E_POINTER;
 
             // Convert adjacency to 'physical' adjacency
             mPhysicalNeighbors.reset(new (std::nothrow) neighborInfo[nFaces]);
@@ -163,14 +163,11 @@ namespace
             _In_reads_(nFaces * 3) const index_t* indices, size_t nFaces,
             size_t faceOffset, size_t faceCount) noexcept
         {
-            if (!faceCount || !indices || !nFaces)
-                return E_INVALIDARG;
-
-            if (faceCount > mMaxSubset)
-                return E_UNEXPECTED;
-
-            if (!mListElements)
+            if (!indices || !mListElements)
                 return E_POINTER;
+
+            if (!faceCount || faceCount > mMaxSubset)
+                return E_UNEXPECTED;
 
             if ((uint64_t(faceOffset) + uint64_t(faceCount)) >= UINT32_MAX)
                 return HRESULT_E_ARITHMETIC_OVERFLOW;
@@ -457,7 +454,7 @@ namespace
         HRESULT initialize(uint32_t cacheSize) noexcept
         {
             if (!cacheSize)
-                return E_INVALIDARG;
+                return E_UNEXPECTED;
 
             mFIFO.reset(new (std::nothrow) uint32_t[cacheSize]);
             if (!mFIFO)
@@ -514,8 +511,8 @@ namespace
         _Out_writes_(nFaces) uint32_t* faceRemap)
     {
         auto subsets = ComputeSubsets(attributes, nFaces);
-
-        assert(!subsets.empty());
+        if (subsets.empty())
+            return E_UNEXPECTED;
 
         mesh_status<index_t> status;
         HRESULT hr = status.initialize(indices, nFaces, adjacency, subsets);
@@ -592,8 +589,8 @@ namespace
         uint32_t vertexCache, uint32_t restart)
     {
         auto subsets = ComputeSubsets(attributes, nFaces);
-
-        assert(!subsets.empty());
+        if (subsets.empty())
+            return E_UNEXPECTED;
 
         mesh_status<index_t> status;
         HRESULT hr = status.initialize(indices, nFaces, adjacency, subsets);

--- a/DirectXMesh/DirectXMeshletGenerator.cpp
+++ b/DirectXMesh/DirectXMeshletGenerator.cpp
@@ -249,7 +249,7 @@ namespace
         std::vector<InlineMeshlet<T>>& meshlets)
     {
         if (!indices || !positions || !adjacency)
-            return E_INVALIDARG;
+            return E_POINTER;
 
         if (subset.first + subset.second > nFaces)
             return E_UNEXPECTED;

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ FOR SECURITY ADVISORIES, see [GitHub](https://github.com/microsoft/DirectXMesh/s
 
 For a full change history, see [CHANGELOG.md](https://github.com/microsoft/DirectXMesh/blob/main/CHANGELOG.md).
 
+* The CMake projects require 3.21 or later. VS 2019 users will need to install a standalone version of CMake 3.21 or later and add it to their PATH.
+
 * Starting with the March 2025 release, Windows 7 and Windows 8.0 support has been retired.
 
 * Starting with the June 2020 release, this library makes use of typed enum bitmask flags per the recommendation of the _C++ Standard_ section _17.5.2.1.3 Bitmask types_. This is consistent with Direct3D 12's use of the ``DEFINE_ENUM_FLAG_OPERATORS`` macro. This may have _breaking change_ impacts to client code:


### PR DESCRIPTION
* CMake 3.21 comes with VS 2022.

> VS 2019 users will need to install a standalone version of a CMake newer than the 3.20 that comes with it.

* Minor code review to return `E_UNEXPECTED` or `E_POINTER` in places that can't be hit in code paths even with invalid input args--i.e. defense-in-depth checks that make static code analysis happy.