### PR TITLE
Update GHA that use VCPKG to support workflow trigger

### DIFF
--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -28,6 +28,7 @@ on:
       - build/*.ps1
       - build/*.targets
       - build/*.xvd
+  workflow_dispatch: {}
 
 permissions:
   contents: read

--- a/.github/workflows/wsl.yml
+++ b/.github/workflows/wsl.yml
@@ -30,6 +30,7 @@ on:
       - build/*.ps1
       - build/*.targets
       - build/*.yml
+  workflow_dispatch: {}
 
 permissions:
   contents: read


### PR DESCRIPTION
This allows manual starting of these actions via the website since they reference repository variables to select which VCPKG baseline they use.