### PR TITLE
Fix for SDK validation pipeline

### DIFF
--- a/.azuredevops/templates/DirectXMesh-build-win32.yml
+++ b/.azuredevops/templates/DirectXMesh-build-win32.yml
@@ -7,62 +7,61 @@
 
 steps:
   - task: VSBuild@1
-    displayName: Build solution DirectXMesh_Desktop_2019.sln 32dbg
+    displayName: Build solution DirectXMesh_Desktop_2022.sln 32dbg
     inputs:
-      solution: DirectXMesh_Desktop_2019.sln
+      solution: DirectXMesh_Desktop_2022.sln
       msbuildArgs: /p:PreferredToolArchitecture=x64
       platform: x86
       configuration: Debug
   - task: VSBuild@1
-    displayName: Build solution DirectXMesh_Desktop_2019.sln 32rel
+    displayName: Build solution DirectXMesh_Desktop_2022.sln 32rel
     inputs:
-      solution: DirectXMesh_Desktop_2019.sln
+      solution: DirectXMesh_Desktop_2022.sln
       msbuildArgs: /p:PreferredToolArchitecture=x64
       platform: x86
       configuration: Release
   - task: VSBuild@1
-    displayName: Build solution DirectXMesh_Desktop_2019.sln 64dbg
+    displayName: Build solution DirectXMesh_Desktop_2022.sln 64dbg
     inputs:
-      solution: DirectXMesh_Desktop_2019.sln
+      solution: DirectXMesh_Desktop_2022.sln
       msbuildArgs: /p:PreferredToolArchitecture=x64
       platform: x64
       configuration: Debug
   - task: VSBuild@1
-    displayName: Build solution DirectXMesh_Desktop_2019.sln 64rel
+    displayName: Build solution DirectXMesh_Desktop_2022.sln 64rel
     inputs:
-      solution: DirectXMesh_Desktop_2019.sln
+      solution: DirectXMesh_Desktop_2022.sln
       msbuildArgs: /p:PreferredToolArchitecture=x64
       platform: x64
       configuration: Release
   - task: VSBuild@1
-    displayName: Build solution DirectXMesh_Desktop_2019_Win10.sln 32dbg
+    displayName: Build solution DirectXMesh_Desktop_2022_Win10.sln 32dbg
     inputs:
-      solution: DirectXMesh_Desktop_2019_Win10.sln
+      solution: DirectXMesh_Desktop_2022_Win10.sln
       msbuildArgs: /p:PreferredToolArchitecture=x64
       platform: x86
       configuration: Debug
   - task: VSBuild@1
-    displayName: Build solution DirectXMesh_Desktop_2019_Win10.sln 32rel
+    displayName: Build solution DirectXMesh_Desktop_2022_Win10.sln 32rel
     inputs:
-      solution: DirectXMesh_Desktop_2019_Win10.sln
+      solution: DirectXMesh_Desktop_2022_Win10.sln
       msbuildArgs: /p:PreferredToolArchitecture=x64
       platform: x86
       configuration: Release
   - task: VSBuild@1
-    displayName: Build solution DirectXMesh_Desktop_2019_Win10.sln 64dbg
+    displayName: Build solution DirectXMesh_Desktop_2022_Win10.sln 64dbg
     inputs:
-      solution: DirectXMesh_Desktop_2019_Win10.sln
+      solution: DirectXMesh_Desktop_2022_Win10.sln
       msbuildArgs: /p:PreferredToolArchitecture=x64
       platform: x64
       configuration: Debug
   - task: VSBuild@1
-    displayName: Build solution DirectXMesh_Desktop_2019_Win10.sln 64rel
+    displayName: Build solution DirectXMesh_Desktop_2022_Win10.sln 64rel
     inputs:
-      solution: DirectXMesh_Desktop_2019_Win10.sln
+      solution: DirectXMesh_Desktop_2022_Win10.sln
       msbuildArgs: /p:PreferredToolArchitecture=x64
       platform: x64
       configuration: Release
-  # VS 2019 for Win32 on ARM64 is out of support.
   - task: VSBuild@1
     displayName: Build solution DirectXMesh_Desktop_2022_Win10.sln arm64dbg
     inputs:


### PR DESCRIPTION
Forgot to update this pipeline for the VS 2019 retirement