### PR TITLE
Fix warnings when upgraded to clang 22

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,20 +275,23 @@ endforeach()
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|IntelLLVM")
     set(WarningsLib -Wall -Wpedantic -Wextra)
     if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 16.0)
-        list(APPEND WarningsLib "-Wno-unsafe-buffer-usage")
+        list(APPEND WarningsLib -Wno-unsafe-buffer-usage)
     endif()
     target_compile_options(${PROJECT_NAME} PRIVATE ${WarningsLib})
 
-    set(WarningsEXE ${WarningsLib} "-Wno-c++98-compat" "-Wno-c++98-compat-pedantic" "-Wno-switch" "-Wno-switch-enum" "-Wno-switch-default" "-Wno-double-promotion" "-Wno-exit-time-destructors" "-Wno-missing-prototypes")
+    set(WarningsEXE ${WarningsLib}
+        -Wno-c++98-compat -Wno-c++98-compat-pedantic
+        -Wno-switch -Wno-switch-enum -Wno-switch-default -Wno-double-promotion -Wno-exit-time-destructors
+        -Wno-missing-prototypes -Wno-padded)
     foreach(t IN LISTS TOOL_EXES)
       target_compile_options(${t} PRIVATE ${WarningsEXE})
     endforeach()
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
     foreach(t IN LISTS TOOL_EXES ITEMS ${PROJECT_NAME})
-      target_compile_options(${t} PRIVATE "-Wno-ignored-attributes" "-Walloc-size-larger-than=4GB")
+      target_compile_options(${t} PRIVATE -Wno-ignored-attributes -Walloc-size-larger-than=4GB)
 
       if(BUILD_SHARED_LIBS)
-        target_compile_options(${t} PRIVATE "-Wno-attributes")
+        target_compile_options(${t} PRIVATE -Wno-attributes)
       endif()
     endforeach()
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")

--- a/DirectXMesh/DirectXMeshP.h
+++ b/DirectXMesh/DirectXMeshP.h
@@ -53,6 +53,7 @@
 #pragma clang diagnostic ignored "-Wc++98-compat-local-type-template-args"
 #pragma clang diagnostic ignored "-Wcovered-switch-default"
 #pragma clang diagnostic ignored "-Wfloat-equal"
+#pragma clang diagnostic ignored "-Wpadded"
 #pragma clang diagnostic ignored "-Wreserved-id-macro"
 #pragma clang diagnostic ignored "-Wundef"
 #pragma clang diagnostic ignored "-Wunknown-warning-option"


### PR DESCRIPTION
* Suppress some noisy warnings that started to spew in clang 22 with VS 2026 18.7

* Minor cmake code review